### PR TITLE
Email Campo Obrigatório UC - Manter Associados

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Models/PessoaViewModel.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Models/PessoaViewModel.cs
@@ -54,6 +54,8 @@ namespace GestaoGrupoMusicalWeb.Models
         [Display(Name = "Telefone 2")]
         public string? Telefone2 { get; set; }
 
+        [Required(ErrorMessage = "O e-mail é obrigatório!")]
+        [Display(Name = "Email")]
         public string? Email { get; set; }
 
         [Display(Name = "Data de entrada")]

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Create.cshtml
@@ -14,7 +14,7 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Id" class="control-label"></label>
-                <input asp-for="Id" class="form-control" />
+                <input asp-for="Id" class="form-control" type="hidden"/>
                 <span asp-validation-for="Id" class="text-danger"></span>
             </div>
             <div class="form-group">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Details.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Details.cshtml
@@ -10,9 +10,6 @@
     <h4>PessoaViewModel</h4>
     <hr />
     <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Id)
-        </dt>
         <dd class = "col-sm-10">
             @Html.DisplayFor(model => model.Id)
         </dd>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Edit.cshtml
@@ -14,7 +14,7 @@
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Id" class="control-label"></label>
-                <input asp-for="Id" class="form-control" />
+                <input asp-for="Id" class="form-control" type="hidden" />
                 <span asp-validation-for="Id" class="text-danger"></span>
             </div>
             <div class="form-group">


### PR DESCRIPTION
foi colocado o email como campo obrigatorio de acordo com o novo modelo de banco de dados.