### PR TITLE
Corrigido bug ao adicionar administrador de um grupo que estava em outro

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/AdministradorGrupoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/AdministradorGrupoMusicalController.cs
@@ -75,7 +75,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
             var pessoa = _pessoaService.Get(id);
             var pessoaViewModel = _mapper.Map<PessoaViewModel>(pessoa);
 
-            ViewBag.idGrupoMusical = pessoa.IdGrupoMusical;
+            ViewBag.idGrupoMusical = pessoaViewModel.IdGrupoMusical;
             ViewBag.nomeGrupo = nomeGrupo;
 
             return View(pessoaViewModel);

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -98,9 +98,9 @@ namespace Service
                 {
                     //id para adm de grupo == 3
                     pessoaF.IdPapelGrupo = 3;
-                    _context.Update(pessoaF);
+                    Edit(pessoaF);
                 }
-                _context.SaveChanges();
+                
 
                 return true;
             }

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -94,11 +94,15 @@ namespace Service
 
                     Create(pessoa);
                 }
-                else
+                else if (pessoaF.IdGrupoMusical == pessoa.IdGrupoMusical)
                 {
                     //id para adm de grupo == 3
                     pessoaF.IdPapelGrupo = 3;
                     Edit(pessoaF);
+                }
+                else
+                {
+                    return false;
                 }
                 
 


### PR DESCRIPTION
# Bug
 O bug consistia em ao adicionar um novo administrador de grupo que já existia (porem estava em outro grupo) o sistema o adicionava como administrador de grupo, mas não do grupo atual.

# Correção
 Atualmente, o sistema verifica se o Id de grupo musical são iguais, caso não sejam o metodo na service retorna false.

# Script para teste

```
START TRANSACTION;

INSERT INTO PESSOA VALUES (null,12345678912,"Lauro Santana","M","49530000","Rua das Flores","Centro",
						   "Ribeirópolis","SE",null,"Sem telefone",null,"lauroteste@email.com",null,null,
                           null,1,0,1,2,3);
                           
INSERT INTO PESSOA VALUES (null,12345678945,"Carlos Daniel","M","49530000","Rua das Dores","Centro",
						   "Ribeirópolis","SE",null,"Com telefone",null,"danielteste@email.com",null,null,
                           null,1,0,1,3,3);

INSERT INTO PESSOA VALUES (null,12345678142,"matheuinhoa","M","49530000","Rua das Flores","Centro",
						   "Ribeirópolis","SE",null,"Sem telefone",null,"lauroteste@email.com",null,null,
                           null,1,0,1,3,3);
                           
INSERT INTO PESSOA VALUES (null,12345678442,"teste pessoa 1","M","49530000","Rua das Flores","Centro",
						   "Ribeirópolis","SE",null,"Sem telefone",null,"lauroteste@email.com",null,null,
                           null,1,0,2,1,3);

INSERT INTO PESSOA VALUES (null,12345691442,"teste pessoa 2","M","49530000","Rua das Flores","Centro",
						   "Ribeirópolis","SE",null,"Sem telefone",null,"lauroteste@email.com",null,null,
                           null,1,0,1,1,3);
						
COMMIT;
```