### PR TITLE
Remover Input Select Colaborador de Movimento Instrumento E adicionar notificações restantes

### DIFF
--- a/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
+++ b/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
@@ -12,6 +12,7 @@ namespace Core.Service
         /// 200 - Sucesso <para />
         /// 400 - Instrumento com status danificado <para />
         /// 401 - Ação de emprestimo/devolução para instrumento já emprestado/devolvido <para />
+        /// 402 - Ação de devolução inválida pois associado não corresponde ao mesmo do empréstimo <para />
         /// 500 - Erro interno
         /// </returns>
         Task<int> CreateAsync(Movimentacaoinstrumento movimentacao);

--- a/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
+++ b/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
@@ -33,6 +33,17 @@ namespace Core.Service
         /// </returns>
         Task<int> DeleteAsync(int id);
 
-        Task<bool> NotificarViaEmailAsync(int id);
+        /// <summary>
+        /// Envia uma notificação sobre o empréstimo/devolução de instrumento
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>
+        /// 200 - Sucesso <para />
+        /// 401 - Instrumento não está cadastrado no sistema <para />
+        /// 402 - Associado não está cadastrado no sistema <para />
+        /// 404 - O id não corresponde a nenhuma movimentação <para />
+        /// 500 - Erro interno
+        /// </returns>
+        Task<int> NotificarViaEmailAsync(int id);
     }
 }

--- a/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
+++ b/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
@@ -21,8 +21,8 @@ namespace Core.Service
 
         Task<IEnumerable<MovimentacaoInstrumentoDTO>> GetAllByIdInstrumento(int idInstrumento);
 
-        Task<bool> Delete(int id);
+        Task<bool> DeleteAsync(int id);
 
-        Task<bool> NotificarViaEmail(int id);
+        Task<bool> NotificarViaEmailAsync(int id);
     }
 }

--- a/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
+++ b/Codigo/Core/Service/IMovimentacaoInstrumentoService.cs
@@ -21,7 +21,17 @@ namespace Core.Service
 
         Task<IEnumerable<MovimentacaoInstrumentoDTO>> GetAllByIdInstrumento(int idInstrumento);
 
-        Task<bool> DeleteAsync(int id);
+        /// <summary>
+        /// Remove uma movimentação no banco de dados
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>
+        /// 200 - Sucesso <para />
+        /// 400 - Movimentação de emprestimo com instrumento não devolvido <para />
+        /// 404 - O id não corresponde a nenhuma movimentação <para />
+        /// 500 - Erro interno
+        /// </returns>
+        Task<int> DeleteAsync(int id);
 
         Task<bool> NotificarViaEmailAsync(int id);
     }

--- a/Codigo/Core/Service/IPessoaService.cs
+++ b/Codigo/Core/Service/IPessoaService.cs
@@ -15,7 +15,7 @@ namespace Core.Service
         void Delete(int id);
         Pessoa Get(int id);
         IEnumerable<Pessoa> GetAll();
-        IEnumerable<AssociadoDTO> GetAllAssociadoDTO();
+        Task<IEnumerable<AssociadoDTO>> GetAllAssociadoDTO();
 
         bool GetCPFExistente(int id, string cpf);
 

--- a/Codigo/Core/Service/IPessoaService.cs
+++ b/Codigo/Core/Service/IPessoaService.cs
@@ -31,5 +31,7 @@ namespace Core.Service
 
         Task<bool> NotificarCadastroAdmGrupoAsync(Pessoa pessoa);
 
+        Task<Pessoa?> GetByCpf(string? cpf);
+
     }
 }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -210,10 +210,10 @@ namespace GestaoGrupoMusicalWeb.Controllers
                             {
                                 Notificar("Instrumento <b>Devolvido</b> com <b>Sucesso</b>", Notifica.Sucesso);
                             }
-                            return RedirectToAction(nameof(Movimentar));
+                            return RedirectToAction(nameof(Movimentar), new { id = movimentacaoPost.IdInstrumentoMusical });
                         case 400:
                             Notificar("Não é possível <b>Emprestar</b> um instrumento <b>Danificado</b>", Notifica.Alerta);
-                            break;
+                            return RedirectToAction(nameof(Movimentar), new { id = movimentacaoPost.IdInstrumentoMusical } );
                         case 401:
                             if (movimentacao.TipoMovimento == "EMPRESTIMO")
                             {
@@ -237,6 +237,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                     Notificar("Desculpe, você não tem <b>permissão</b> para realizar essa <b>operação</b>", Notifica.Erro);
                 }
             }
+
             return View(movimentacaoPost);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -171,8 +171,10 @@ namespace GestaoGrupoMusicalWeb.Controllers
 
             var listaPessoas = _pessoa.GetAll().ToList();
             listaPessoas.Remove(listaPessoas.Single(p => p.Cpf == User.Identity?.Name));
-
-            movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
+            if (listaPessoas.Any())
+            {
+                movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
+            }
             return View(movimentacaoModel);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -227,7 +227,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
         {
             try
             {
-                await _movimentacaoInstrumento.Delete(id);
+                await _movimentacaoInstrumento.DeleteAsync(id);
                 return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
             }
             catch
@@ -242,7 +242,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
         {
             try
             {
-                await _movimentacaoInstrumento.NotificarViaEmail(id);
+                await _movimentacaoInstrumento.NotificarViaEmailAsync(id);
                 return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
             }
             catch

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -170,11 +170,8 @@ namespace GestaoGrupoMusicalWeb.Controllers
             movimentacaoModel.NomeInstrumento = await _instrumentoMusical.GetNomeInstrumento(id);
 
             var listaPessoas = _pessoa.GetAll().ToList();
-            var admLogado = listaPessoas.SingleOrDefault(p => p.Cpf == User.Identity?.Name);
-            if (admLogado != null)
-            {
-                listaPessoas.Remove(admLogado);
-            }
+            listaPessoas.Remove(listaPessoas.Single(p => p.Cpf == User.Identity?.Name));
+
             movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
             return View(movimentacaoModel);
         }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -205,8 +205,11 @@ namespace GestaoGrupoMusicalWeb.Controllers
                                 Notificar("Não é possível <b>Devolver</b> um instrumento que não está <b>Emprestado</b>", Notifica.Alerta);
                             }
                             break;
+                        case 402:
+                                Notificar("Esse <b>Associado</b> não corresponde ao <b>Empréstimo</b> desse <b>Instrumento</b>", Notifica.Erro);
+                            break;
                         case 500:
-                            Notificar("Desculpe, ocorreu um <b>Erro</b> durante a <b>Movimentação</b> do instrumento, se isso persistir entre em contato com o suporte", Notifica.Erro);
+                                Notificar("Desculpe, ocorreu um <b>Erro</b> durante a <b>Movimentação</b> do instrumento, se isso persistir entre em contato com o suporte", Notifica.Erro);
                             break;
                     }
                 }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -5,10 +5,6 @@ using GestaoGrupoMusicalWeb.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using System.Data;
-using System.Diagnostics.Metrics;
-using System.Runtime.Intrinsics.X86;
 
 namespace GestaoGrupoMusicalWeb.Controllers
 {
@@ -234,7 +230,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                     Notificar("Movimentação <b>Excluida</b> com <b>Sucesso</b>", Notifica.Sucesso);
                 break;
                 case 400:
-                    Notificar("Não é possível <b>Excluir</b> uma <b>Movimentação</b> de <b>Empréstimo</b> para um instrumento não <b>Devolvido</b>", Notifica.Alerta);
+                    Notificar("Não é possível <b>Excluir</b> essa <b>Movimentação</b> de <b>Empréstimo</b> pois o instrumento não foi <b>Devolvido</b>", Notifica.Alerta);
                 break;
                 case 404:
                     Notificar($"O Id {id} não <b>Corresponde</b> a nenhuma <b>Movimentação</b>", Notifica.Erro);
@@ -251,14 +247,24 @@ namespace GestaoGrupoMusicalWeb.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> NotificarViaEmail(int id, int IdInstrumento)
         {
-            if(await _movimentacaoInstrumento.NotificarViaEmailAsync(id))
+            switch(await _movimentacaoInstrumento.NotificarViaEmailAsync(id))
             {
-                Notificar("Notificação <b>Enviada</b> com <b>Sucesso</b>", Notifica.Sucesso);
-            }
-            else
-            {
-                Notificar("Desculpe, ocorreu um <b>Erro</b> durante o <b>Envio</b> de notificação, se isso persistir entre em contato com o suporte", Notifica.Erro);
-            }
+                case 200:
+                    Notificar("Notificação <b>Enviada</b> com <b>Sucesso</b>", Notifica.Sucesso);
+                break;
+                case 401:
+                    Notificar("O instrumento <b>Não</b> está <b>Cadastrado</b> no sistema, por favor entre em contato com o suporte", Notifica.Erro);
+                break;
+                case 402:
+                    Notificar("O correspondente <b>Não</b> está <b>Cadastrado</b> no sistema, por favor entre em contato com o suporte", Notifica.Erro);
+                break;
+                case 404:
+                    Notificar($"O Id {id} não <b>Corresponde</b> a nenhuma <b>Movimentação</b>", Notifica.Erro);
+                break;
+                case 500:
+                    Notificar("Desculpe, ocorreu um <b>Erro</b> durante o <b>Envio</b> da notificação, se isso persistir entre em contato com o suporte", Notifica.Erro);
+                    break;
+            }  
             return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
         }
     }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -149,7 +149,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
             movimentacaoModel.Patrimonio = instrumento.Patrimonio;
             movimentacaoModel.IdInstrumentoMusical = instrumento.Id;
             movimentacaoModel.NomeInstrumento = await _instrumentoMusical.GetNomeInstrumento(id);
-            movimentacaoModel.ListaAssociado = new SelectList(_pessoa.GetAll(), "Id", "Nome");
+            movimentacaoModel.ListaAssociado = new SelectList(await _pessoa.GetAllAssociadoDTO(), "Id", "Nome");
             return View(movimentacaoModel);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -138,6 +138,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
 
             if(instrumento == null)
             {
+                Notificar($"O Id {id} não <b>Corresponde</b> a nenhuma <b>Movimentação</b>", Notifica.Erro);
                 return RedirectToAction(nameof(Index));
             }
 
@@ -236,7 +237,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                     Notificar("Não é possível <b>Excluir</b> uma <b>Movimentação</b> de <b>Empréstimo</b> para um instrumento não <b>Devolvido</b>", Notifica.Alerta);
                 break;
                 case 404:
-                    Notificar($"O Id {id} não <b>Corresponde</b> a nenhuma <b>Movimentação</b> registrada", Notifica.Erro);
+                    Notificar($"O Id {id} não <b>Corresponde</b> a nenhuma <b>Movimentação</b>", Notifica.Erro);
                 break;
                 case 500:
                     Notificar("Desculpe, ocorreu um <b>Erro</b> durante a <b>Exclusão</b> da movimentação, se isso persistir entre em contato com o suporte", Notifica.Erro);

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -225,30 +225,31 @@ namespace GestaoGrupoMusicalWeb.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> DeleteMovimentacao(int id, int IdInstrumento)
         {
-            try
+            if(await _movimentacaoInstrumento.DeleteAsync(id))
             {
-                await _movimentacaoInstrumento.DeleteAsync(id);
-                return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
+                Notificar("Movimentação <b>Excluida</b> com <b>Sucesso</b>", Notifica.Sucesso);
             }
-            catch
+            else
             {
-                return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
+                Notificar("Desculpe, ocorreu um <b>Erro</b> durante a <b>Exclusão</b> da movimentação, se isso persistir entre em contato com o suporte", Notifica.Erro);
             }
+
+            return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
         }
 
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> NotificarViaEmail(int id, int IdInstrumento)
         {
-            try
+            if(await _movimentacaoInstrumento.NotificarViaEmailAsync(id))
             {
-                await _movimentacaoInstrumento.NotificarViaEmailAsync(id);
-                return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
+                Notificar("Notificação <b>Enviada</b> com <b>Sucesso</b>", Notifica.Sucesso);
             }
-            catch
+            else
             {
-                return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
+                Notificar("Desculpe, ocorreu um <b>Erro</b> durante o <b>Envio</b> de notificação, se isso persistir entre em contato com o suporte", Notifica.Erro);
             }
+            return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });
         }
     }
 }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -149,7 +149,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
             movimentacaoModel.Patrimonio = instrumento.Patrimonio;
             movimentacaoModel.IdInstrumentoMusical = instrumento.Id;
             movimentacaoModel.NomeInstrumento = await _instrumentoMusical.GetNomeInstrumento(id);
-            movimentacaoModel.ListaAssociado = new SelectList(await _pessoa.GetAllAssociadoDTO(), "Id", "Nome");
+            movimentacaoModel.ListaAssociado = new SelectList(_pessoa.GetAll(), "Id", "Nome");
             return View(movimentacaoModel);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -170,11 +170,12 @@ namespace GestaoGrupoMusicalWeb.Controllers
             movimentacaoModel.NomeInstrumento = await _instrumentoMusical.GetNomeInstrumento(id);
 
             var listaPessoas = _pessoa.GetAll().ToList();
-            listaPessoas.Remove(listaPessoas.Single(p => p.Cpf == User.Identity?.Name));
-            if (listaPessoas.Any())
+            var admLogado = listaPessoas.SingleOrDefault(p => p.Cpf == User.Identity?.Name);
+            if (admLogado != null)
             {
-                movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
+                listaPessoas.Remove(admLogado);
             }
+            movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
             return View(movimentacaoModel);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using System.Data;
+using System.Diagnostics.Metrics;
+using System.Runtime.Intrinsics.X86;
 
 namespace GestaoGrupoMusicalWeb.Controllers
 {
@@ -225,13 +227,20 @@ namespace GestaoGrupoMusicalWeb.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> DeleteMovimentacao(int id, int IdInstrumento)
         {
-            if(await _movimentacaoInstrumento.DeleteAsync(id))
+            switch(await _movimentacaoInstrumento.DeleteAsync(id))
             {
-                Notificar("Movimentação <b>Excluida</b> com <b>Sucesso</b>", Notifica.Sucesso);
-            }
-            else
-            {
-                Notificar("Desculpe, ocorreu um <b>Erro</b> durante a <b>Exclusão</b> da movimentação, se isso persistir entre em contato com o suporte", Notifica.Erro);
+                case 200:
+                    Notificar("Movimentação <b>Excluida</b> com <b>Sucesso</b>", Notifica.Sucesso);
+                break;
+                case 400:
+                    Notificar("Não é possível <b>Excluir</b> uma <b>Movimentação</b> de <b>Empréstimo</b> para um instrumento não <b>Devolvido</b>", Notifica.Alerta);
+                break;
+                case 404:
+                    Notificar($"O Id {id} não <b>Corresponde</b> a nenhuma <b>Movimentação</b> registrada", Notifica.Erro);
+                break;
+                case 500:
+                    Notificar("Desculpe, ocorreu um <b>Erro</b> durante a <b>Exclusão</b> da movimentação, se isso persistir entre em contato com o suporte", Notifica.Erro);
+                break;
             }
 
             return RedirectToAction(nameof(Movimentar), new { id = IdInstrumento });

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -170,8 +170,11 @@ namespace GestaoGrupoMusicalWeb.Controllers
             movimentacaoModel.NomeInstrumento = await _instrumentoMusical.GetNomeInstrumento(id);
 
             var listaPessoas = _pessoa.GetAll().ToList();
-            listaPessoas.Remove(listaPessoas.Single(p => p.Cpf == User.Identity?.Name));
-
+            var admLogado = listaPessoas.SingleOrDefault(p => p.Cpf == User.Identity?.Name);
+            if (admLogado != null)
+            {
+                listaPessoas.Remove(admLogado);
+            }
             movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
             return View(movimentacaoModel);
         }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -149,7 +149,11 @@ namespace GestaoGrupoMusicalWeb.Controllers
             movimentacaoModel.Patrimonio = instrumento.Patrimonio;
             movimentacaoModel.IdInstrumentoMusical = instrumento.Id;
             movimentacaoModel.NomeInstrumento = await _instrumentoMusical.GetNomeInstrumento(id);
-            movimentacaoModel.ListaAssociado = new SelectList(_pessoa.GetAll(), "Id", "Nome");
+
+            var listaPessoas = _pessoa.GetAll().ToList();
+            listaPessoas.Remove(listaPessoas.Single(p => p.Cpf == User.Identity?.Name));
+
+            movimentacaoModel.ListaAssociado = new SelectList(listaPessoas, "Id", "Nome");
             return View(movimentacaoModel);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/PessoaController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/PessoaController.cs
@@ -24,9 +24,9 @@ namespace GestaoGrupoMusicalWeb.Controllers
         }
 
         // GET: PessoaController
-        public ActionResult Index()
+        public async Task<ActionResult> Index()
         {
-            var listaPessoasDTO = _pessoaService.GetAllAssociadoDTO();
+            var listaPessoasDTO = await _pessoaService.GetAllAssociadoDTO();
 
             return View(listaPessoasDTO);
         }

--- a/Codigo/GestaoGrupoMusicalWeb/Models/MovimentacaoInstrumentoViewModel.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Models/MovimentacaoInstrumentoViewModel.cs
@@ -16,11 +16,6 @@ namespace GestaoGrupoMusicalWeb.Models
         [Required(ErrorMessage = "O campo {0} é obrigatório")]
         public int IdAssociado { get; set; }
 
-        //TODO: Remover essa propriedade apos autenticacao
-        [Display(Name = "Colaborador")]
-        [Required (ErrorMessage = "O campo {0} é obrigatório")]
-        public int IdColaborador { get; set; }
-
         public int IdInstrumentoMusical { get; set; }
 
         public DateTime Data { get; set; } = DateTime.Now;

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Index.cshtml
@@ -32,20 +32,20 @@
         </thead>
         <tbody>
             @foreach (var item in Model) {
-                <tr class="border-bottom border-danger border-opacity-75 p-3 align-middle">
-                    <td class="p-3" >
+                <tr class="border-bottom border-danger border-opacity-75 align-middle">
+                    <td>
                         @item.Patrimonio
                     </td>
-                    <td class="p-3" >
+                    <td>
                         @item.NomeInstrumento
                     </td>
-                    <td class="p-3">
+                    <td>
                         @item.Status
                     </td>
-                    <td class="p-3">
+                    <td>
                         @item.NomeAssociado
                     </td>
-                    <td class="d-flex flex-wrap justify-content-between border-0 p-3">
+                    <td class="d-flex flex-wrap justify-content-between border-0">
                         <a role="button" class="btn btn-secondary btn-sm px-3 my-2" asp-controller="InstrumentoMusical" asp-action="Edit" asp-route-id="@item.Id"><i class="fa-solid fa-pen-to-square"> </i> Editar </a>
                         <a role="button" class="btn btn-secondary btn-sm px-3 my-2" asp-controller="InstrumentoMusical" asp-action="Delete" asp-route-id="@item.Id"><i class="fa-solid fa-xmark"> </i> Excluir </a>
                         <a role="button" class="btn btn-secondary btn-sm px-3 my-2" asp-controller="InstrumentoMusical" asp-action="Movimentar" asp-route-id="@item.Id"><i class="fa-solid fa-arrow-right-arrow-left"></i> Movimentar </a>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Index.cshtml
@@ -12,21 +12,21 @@
 <div class="table-responsive-md">
     <table class="table">
         <thead>
-            <tr class="bg-danger opacity-75" >
+            <tr class="bg-danger bg-opacity-75 text-white">
                 <th>
-                    <span class="text-white">Patrimônio</span>
+                    @Html.DisplayNameFor(m => m.Patrimonio)
                 </th>
                 <th>
-                    <span class="text-white">Instrumento</span>
+                    @Html.DisplayNameFor(m => m.NomeInstrumento)
                 </th>
                 <th>
-                    <span class="text-white">Status</span>
+                    @Html.DisplayNameFor(m => m.Status)
                 </th>
                 <th>
-                    <span class="text-white">Associado</span>
+                    @Html.DisplayNameFor(m => m.NomeAssociado)
                 </th>
                 <th>
-                    <span class="text-white">Ações</span>
+                    <span>Ações</span>
                 </th>
             </tr>
         </thead>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
@@ -25,10 +25,20 @@
         <div class="row mb-3">
             <div>
                 <label asp-for="IdAssociado" class="control-label"></label>
-                <select asp-for="IdAssociado" asp-items="@Model.ListaAssociado" class="form-select">
-                    <option value=""></option>
-                </select>
-                <span asp-validation-for="IdAssociado" class="text-danger"></span>
+                    @if (Model.IdAssociado != 0)
+                    {
+                        <select asp-for="IdAssociado" asp-items="@Model.ListaAssociado" class="form-select" disabled>
+                            <option value=""></option>
+                        </select>
+                        <input asp-for="IdAssociado" type="hidden"/>
+                    }
+                    else
+                    {
+                        <select asp-for="IdAssociado" asp-items="@Model.ListaAssociado" class="form-select">
+                            <option value=""></option>
+                        </select>
+                    }
+                    <span asp-validation-for="IdAssociado" class="text-danger"></span>
             </div>
         </div>
         <div class="row mb-3">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
@@ -64,7 +64,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="d-flex justify-content-lg-end flex-column flex-lg-row">
+            <div class="d-flex justify-content-lg-end flex-column-reverse flex-lg-row">
                 <a class="btn btn-outline-secondary col-lg-2 mt-3 me-lg-3" asp-controller="InstrumentoMusical" asp-action="Index">Voltar</a>
                 <input class="btn btn-secondary col-lg-2 mt-3 ml-3" type="submit" value="Adicionar" />
             </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
@@ -65,8 +65,8 @@
         </div>
         <div class="row">
             <div class="d-flex justify-content-lg-end flex-column flex-lg-row">
-                <a class="btn btn-light col-lg-2 mt-3 me-lg-3" asp-controller="InstrumentoMusical" asp-action="Index">Voltar</a>
-                <input class="btn btn-primary col-lg-2 mt-3 ml-3" type="submit" value="Adicionar" />
+                <a class="btn btn-outline-secondary col-lg-2 mt-3 me-lg-3" asp-controller="InstrumentoMusical" asp-action="Index">Voltar</a>
+                <input class="btn btn-secondary col-lg-2 mt-3 ml-3" type="submit" value="Adicionar" />
             </div>
         </div>
     </form>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
@@ -32,15 +32,6 @@
             </div>
         </div>
         <div class="row mb-3">
-            <div>
-                <label asp-for="IdColaborador" class="control-label"></label>
-                <select asp-for="IdColaborador" asp-items="@Model.ListaAssociado" class="form-select">
-                    <option value=""></option>
-                </select>
-                <span asp-validation-for="IdColaborador" class="text-danger"></span>
-            </div>
-        </div>
-        <div class="row mb-3">
             <div class="col-lg-6">
                 <label asp-for="Movimentacao" class="control-label"></label>
                 <div class="d-flex justify-content-around">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Movimentar.cshtml
@@ -45,15 +45,15 @@
             <div class="col-lg-6">
                 <label asp-for="Movimentacao" class="control-label"></label>
                 <div class="d-flex justify-content-around">
-                    @{
-                        foreach (var item in Model.MovimentacaoEnum)
-                        {
-                            <div>
-                                <label for="@item.Key">@item.Key</label>
-                                <input type="radio" value="@item.Value" asp-for="Movimentacao" id="@item.Key" />
-                            </div>
-                        }
+                @{
+                    foreach (var item in Model.MovimentacaoEnum)
+                    {
+                        <div>
+                            <label for="@item.Key">@item.Key</label>
+                            <input class="form-check-input" type="radio" value="@item.Value" asp-for="Movimentacao" id="@item.Key" />
+                        </div>
                     }
+                }
                 </div>
                 <span asp-validation-for="Movimentacao" class="text-danger"></span>
             </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/_TabelaMovimentacao.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/_TabelaMovimentacao.cshtml
@@ -1,9 +1,9 @@
 ﻿@model IEnumerable<Core.DTO.MovimentacaoInstrumentoDTO>
 
-<div class="table-responsive-md">
-    <table class="table table table-bordered mt-3">
-        <thead class="table-light">
-            <tr>
+<div class="table-responsive">
+    <table class="table mt-3">
+        <thead>
+            <tr class="bg-danger bg-opacity-75 text-white">
                 <th>
                     @Html.DisplayNameFor(model => model.Cpf)
                 </th>
@@ -25,7 +25,7 @@
         <tbody>
             @foreach (var item in Model)
             {
-                <tr>
+                <tr class="border-bottom border-danger border-opacity-75 align-middle">
                     <td>
                         @item.Cpf
                     </td>
@@ -41,18 +41,19 @@
                     <td>
                         @item.Status
                     </td>
-                    <td>
-                        <form id="@(item.Id + "_delete")" asp-controller="InstrumentoMusical" asp-action="DeleteMovimentacao" asp-route-Id="@item.Id" asp-route-IdInstrumento="@item.IdInstrumento" method="post">
-                            <a role="button" class="link-primary"
-                               onclick="(() => {confirm('Deseja excluir a movimentação?') ? document.getElementById('@(item.Id + "_delete")').submit() : null})()">
-                                Excluir
+                    <td class="py-3 border-0 d-flex flex-column flex-lg-row gap-3">
+                        <form id="@(item.Id + "_notificar")" asp-controller="InstrumentoMusical" asp-action="NotificarViaEmail" asp-route-Id="@item.Id" asp-route-IdInstrumento="@item.IdInstrumento" method="post">
+                            <a role="button" class="btn btn-sm btn-secondary"
+                               onclick="(() => {confirm('Deseja notificar a movimentação?') ? document.getElementById('@(item.Id + "_notificar")').submit() : null})()">
+                                <i class="fa-solid fa-envelope"></i>
+                                Notificar
                             </a>
                         </form>
-                        |
-                        <form id="@(item.Id + "_notificar")" asp-controller="InstrumentoMusical" asp-action="NotificarViaEmail" asp-route-Id="@item.Id" asp-route-IdInstrumento="@item.IdInstrumento" method="post">
-                            <a role="button" class="link-primary"
-                               onclick="(() => {confirm('Deseja notificar a movimentação?') ? document.getElementById('@(item.Id + "_notificar")').submit() : null})()">
-                                Notificar
+                        <form id="@(item.Id + "_delete")" asp-controller="InstrumentoMusical" asp-action="DeleteMovimentacao" asp-route-Id="@item.Id" asp-route-IdInstrumento="@item.IdInstrumento" method="post">
+                            <a role="button" class="btn btn-sm btn-secondary"
+                               onclick="(() => {confirm('Deseja excluir a movimentação?') ? document.getElementById('@(item.Id + "_delete")').submit() : null})()">
+                                <i class="fa-solid fa-xmark"> </i>
+                                Excluir
                             </a>
                         </form>
                     </td>

--- a/Codigo/GestaoGrupoMusicalWeb/wwwroot/css/site.css
+++ b/Codigo/GestaoGrupoMusicalWeb/wwwroot/css/site.css
@@ -95,6 +95,7 @@ html {
 }
 
 .form-check-input:checked {
-    background-color: var(--bs-success);
-    border-color: var(--bs-success);
+    border-color: rgba(var(--bs-danger-rgb), 0.75);
+    background-color: rgba(var(--bs-danger-rgb), 0.75);
+    background-clip: padding-box
 }

--- a/Codigo/Service/InstrumentoMusicalService.cs
+++ b/Codigo/Service/InstrumentoMusicalService.cs
@@ -45,20 +45,23 @@ namespace Service
 
         public async Task<IEnumerable<InstrumentoMusicalDTO>> GetAllDTO()
         {
-            var query = await   (from instrumento in _context.Instrumentomusicals
-                                join movimentacao in _context.Movimentacaoinstrumentos
-                                on instrumento.Id equals movimentacao.IdInstrumentoMusical into intMovi
-                                from instrumentoMovi in intMovi.DefaultIfEmpty()
-                                select new InstrumentoMusicalDTO
-                                {
-                                    Id = instrumento.Id,
-                                    Patrimonio = instrumento.Patrimonio,
-                                    NomeInstrumento = instrumento.IdTipoInstrumentoNavigation.Nome,
-                                    Status = instrumento.Status,
-                                    NomeAssociado = instrumentoMovi.IdAssociadoNavigation.Nome
-                                }).AsNoTracking().Distinct().ToListAsync();
-    
-            foreach (var instrumento in query)
+            var query = await (from instrumento in _context.Instrumentomusicals
+                               join movimentacao in _context.Movimentacaoinstrumentos
+                               on instrumento.Id equals movimentacao.IdInstrumentoMusical into intMovi
+                               from instrumentoMovi in intMovi.DefaultIfEmpty()
+                               orderby instrumentoMovi.Data descending
+                               select new InstrumentoMusicalDTO
+                               {
+                                   Id = instrumento.Id,
+                                   Patrimonio = instrumento.Patrimonio,
+                                   NomeInstrumento = instrumento.IdTipoInstrumentoNavigation.Nome,
+                                   Status = instrumento.Status,
+                                   NomeAssociado = instrumentoMovi.IdAssociadoNavigation.Nome
+                               }).AsNoTracking().ToListAsync();
+
+            var list = query.DistinctBy(m => m.Patrimonio).OrderBy(m => m.Patrimonio);
+     
+            foreach (var instrumento in list)
             {
                 if (instrumento.Status == "DISPONIVEL")
                 {
@@ -67,7 +70,7 @@ namespace Service
                 instrumento.Status = instrumento.EnumStatus.Single(s => s.Key == instrumento.Status).Value;
             }
 
-            return query;
+            return list;
         }
 
         public async Task<IEnumerable<Tipoinstrumento>> GetAllTipoInstrumento()

--- a/Codigo/Service/InstrumentoMusicalService.cs
+++ b/Codigo/Service/InstrumentoMusicalService.cs
@@ -59,7 +59,7 @@ namespace Service
                                    NomeAssociado = instrumentoMovi.IdAssociadoNavigation.Nome
                                }).AsNoTracking().ToListAsync();
 
-            var list = query.DistinctBy(m => m.Patrimonio).OrderBy(m => m.Patrimonio);
+            var list = query.DistinctBy(m => m.Patrimonio).OrderBy(m => m.NomeInstrumento);
      
             foreach (var instrumento in list)
             {

--- a/Codigo/Service/MovimentacaoInstrumentoService.cs
+++ b/Codigo/Service/MovimentacaoInstrumentoService.cs
@@ -109,7 +109,7 @@ namespace Service
             }
         }
 
-        public async Task<bool> Delete(int id)
+        public async Task<bool> DeleteAsync(int id)
         {
             try
             {
@@ -170,7 +170,7 @@ namespace Service
             return await query;
         }
 
-        public async Task<bool> NotificarViaEmail(int id)
+        public async Task<bool> NotificarViaEmailAsync(int id)
         {
             try
             {

--- a/Codigo/Service/MovimentacaoInstrumentoService.cs
+++ b/Codigo/Service/MovimentacaoInstrumentoService.cs
@@ -109,22 +109,30 @@ namespace Service
             }
         }
 
-        public async Task<bool> DeleteAsync(int id)
+        public async Task<int> DeleteAsync(int id)
         {
             try
             {
                 var movimentacao = await _context.Movimentacaoinstrumentos.FindAsync(id);
                 if (movimentacao != null)
                 {
-                    _context.Movimentacaoinstrumentos.Remove(movimentacao);
-                    await _context.SaveChangesAsync();
-                    return true;
+                    var movimentacaoDb = await GetEmprestimoByIdInstrumento(movimentacao.IdInstrumentoMusical);
+                    if (movimentacaoDb != null)
+                    {
+                        if (movimentacaoDb.Id == movimentacao.Id)
+                        {
+                            return 400;
+                        }
+                         _context.Movimentacaoinstrumentos.Remove(movimentacao);
+                        await _context.SaveChangesAsync();
+                        return 200;
+                    }
                 }
-                return false;
+                return 404;
             }
             catch
             {
-                return false;
+                return 500;
             }
         }
 

--- a/Codigo/Service/MovimentacaoInstrumentoService.cs
+++ b/Codigo/Service/MovimentacaoInstrumentoService.cs
@@ -59,35 +59,42 @@ namespace Service
                     }
                     else if(movimentacao.TipoMovimento == "DEVOLUCAO" && instrumento.Status == "EMPRESTADO")
                     {
-                        instrumento.Status = "DISPONIVEL";
-                        _context.Instrumentomusicals.Update(instrumento);
+                        var emprestimo = await GetEmprestimoByIdInstrumento(instrumento.Id);
 
-                        await _context.SaveChangesAsync();
-                        await transaction.CommitAsync();
-
-                        var associado = await _context.Pessoas.FindAsync(movimentacao.IdAssociado);
-                        string? instrumentoNome = (await _context.Tipoinstrumentos.FindAsync(instrumento.IdTipoInstrumento))?.Nome;
-                        if (associado != null)
+                        if (emprestimo != null && movimentacao.IdAssociado == emprestimo.IdAssociado)
                         {
-                            EmailModel email = new()
+                            instrumento.Status = "DISPONIVEL";
+                            _context.Instrumentomusicals.Update(instrumento);
+
+                            await _context.SaveChangesAsync();
+                            await transaction.CommitAsync();
+
+                            var associado = await _context.Pessoas.FindAsync(movimentacao.IdAssociado);
+                            string? instrumentoNome = (await _context.Tipoinstrumentos.FindAsync(instrumento.IdTipoInstrumento))?.Nome;
+                            if (associado != null)
                             {
-                                Assunto = "Batalá - Devolução de instrumento",
-                                Body = "<div style=\"text-align: center;\">\r\n    " +
-                                "<h1>Devolução de instrumento</h1>\r\n    " +
-                                $"<h2>Olá, {associado.Nome}, estamos aguardando a sua confirmação de devolução.</h2>\r\n" +
-                                "<div style=\"font-size: large;\">\r\n        " +
-                                $"<dt style=\"font-weight: 700;\">Instrumento:</dt><dd>{instrumentoNome}</dd>" +
-                                $"<dt style=\"font-weight: 700;\">Data de Devolução:</dt><dd>{movimentacao.Data:dd/MM/yyyy}</dd>\n</div>"
-                            };
+                                EmailModel email = new()
+                                {
+                                    Assunto = "Batalá - Devolução de instrumento",
+                                    Body = "<div style=\"text-align: center;\">\r\n    " +
+                                    "<h1>Devolução de instrumento</h1>\r\n    " +
+                                    $"<h2>Olá, {associado.Nome}, estamos aguardando a sua confirmação de devolução.</h2>\r\n" +
+                                    "<div style=\"font-size: large;\">\r\n        " +
+                                    $"<dt style=\"font-weight: 700;\">Instrumento:</dt><dd>{instrumentoNome}</dd>" +
+                                    $"<dt style=\"font-weight: 700;\">Data de Devolução:</dt><dd>{movimentacao.Data:dd/MM/yyyy}</dd>\n</div>"
+                                };
 
-                            email.To.Add(associado.Email);
+                                email.To.Add(associado.Email);
 
-                            await EmailService.Enviar(email);
+                                await EmailService.Enviar(email);
+                            }
+
+                            return 200;
                         }
-
-                        return 200;
+                        await transaction.RollbackAsync();
+                        return 402;
                     }
-
+                    await transaction.RollbackAsync();
                     return 401;
                 }
                 
@@ -157,6 +164,7 @@ namespace Service
             var query = (from movimentacao in _context.Movimentacaoinstrumentos
                         where movimentacao.IdInstrumentoMusical == idInstrumento
                         where movimentacao.TipoMovimento == "EMPRESTIMO"
+                        orderby movimentacao.Data descending
                         select movimentacao).AsNoTracking().FirstOrDefaultAsync();
 
             return await query;

--- a/Codigo/Service/MovimentacaoInstrumentoService.cs
+++ b/Codigo/Service/MovimentacaoInstrumentoService.cs
@@ -178,7 +178,7 @@ namespace Service
             return await query;
         }
 
-        public async Task<bool> NotificarViaEmailAsync(int id)
+        public async Task<int> NotificarViaEmailAsync(int id)
         {
             try
             {
@@ -189,34 +189,42 @@ namespace Service
                     var associado = await _context.Pessoas.FindAsync(movimentacao.IdAssociado);
                     string tipoMovimentacao = movimentacao.TipoMovimento == "DEVOLUCAO" ? "Devolução" : "Empréstimo";
 
-                    if (associado != null && instrumento != null)
+                    if(associado == null)
                     {
-                        string? instrumentoNome = (await _context.Tipoinstrumentos.FindAsync(instrumento.IdTipoInstrumento))?.Nome;
-
-                        EmailModel email = new()
-                        {
-                            Assunto = $"Batalá - {tipoMovimentacao} de instrumento",
-                            Body = "<div style=\"text-align: center;\">\r\n    " +
-                                    $"<h1>{tipoMovimentacao} de instrumento</h1>\r\n    " +
-                                    $"<h2>Olá, {associado.Nome}, estamos aguardando a sua confirmação de {tipoMovimentacao}.</h2>\r\n" +
-                                    "<div style=\"font-size: large;\">\r\n        " +
-                                    $"<dt style=\"font-weight: 700;\">Instrumento:</dt><dd>{instrumentoNome}</dd>" +
-                                    $"<dt style=\"font-weight: 700;\">Data de {tipoMovimentacao}:</dt><dd>{movimentacao.Data:dd/MM/yyyy}</dd>\n</div>"
-                        };
-
-                        email.To.Add(associado.Email);
-
-                        await EmailService.Enviar(email);
-
-                        return true;
+                        return 402;
                     }
+
+                    if(instrumento == null)
+                    {
+                        return 401;
+                    }
+
+                    string? instrumentoNome = (await _context.Tipoinstrumentos.FindAsync(instrumento.IdTipoInstrumento))?.Nome;
+
+                    EmailModel email = new()
+                    {
+                        Assunto = $"Batalá - {tipoMovimentacao} de instrumento",
+                        Body = "<div style=\"text-align: center;\">\r\n    " +
+                                $"<h1>{tipoMovimentacao} de instrumento</h1>\r\n    " +
+                                $"<h2>Olá, {associado.Nome}, estamos aguardando a sua confirmação de {tipoMovimentacao}.</h2>\r\n" +
+                                "<div style=\"font-size: large;\">\r\n        " +
+                                $"<dt style=\"font-weight: 700;\">Instrumento:</dt><dd>{instrumentoNome}</dd>" +
+                                $"<dt style=\"font-weight: 700;\">Data de {tipoMovimentacao}:</dt><dd>{movimentacao.Data:dd/MM/yyyy}</dd>\n</div>"
+                    };
+
+                    email.To.Add(associado.Email);
+
+                    await EmailService.Enviar(email);
+
+                    return 200;
+                    
                 }
 
-                return false;
+                return 404;
             }
             catch
             {
-                return false;
+                return 500;
             }
         }
     }

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -354,5 +354,14 @@ namespace Service
             }
             return false;
         }
+
+        public async Task<Pessoa?> GetByCpf(string? cpf)
+        {
+            var query = (from pessoa in _context.Pessoas
+                        where pessoa.Cpf == cpf
+                        select pessoa).FirstOrDefaultAsync();
+
+            return await query;
+        }
     }
 }

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -194,7 +194,11 @@ namespace Service
                     pessoa.IsentoPagamento = 1;
                     pessoa.Telefone1 = "";
 
-                    await Create(pessoa);
+                    if(await Create(pessoa) != 200)
+                    {
+                        await transaction.RollbackAsync();
+                        return false;
+                    }
 
                     var user = CreateUser();
 
@@ -254,7 +258,11 @@ namespace Service
 
                     //id para adm de grupo == 3
                     pessoaF.IdPapelGrupo = 3;
-                    await Edit(pessoaF);
+                    if(await Edit(pessoaF) != 200)
+                    {
+                        await transaction.RollbackAsync();
+                        return false;
+                    }
                 }
                 else
                 {

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -177,6 +177,8 @@ namespace Service
 
         public async Task<bool> AddAdmGroup(Pessoa pessoa)
         {
+            using var transaction = _context.Database.BeginTransaction();
+
             try
             {
                 //faz uma consulta para tentar buscar a primeira pessoa com o cpf que foi digitado
@@ -252,18 +254,20 @@ namespace Service
 
                     //id para adm de grupo == 3
                     pessoaF.IdPapelGrupo = 3;
-                    Edit(pessoaF);
+                    await Edit(pessoaF);
                 }
                 else
                 {
+                    await transaction.RollbackAsync();
                     return false;
                 }
 
-
+                await transaction.CommitAsync();
                 return true;
             }
             catch
             {
+                await transaction.RollbackAsync();
                 return false;
             }
         }

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -226,16 +226,20 @@ namespace Service
 
         }
 
-        public IEnumerable<AssociadoDTO> GetAllAssociadoDTO()
+        public async Task<IEnumerable<AssociadoDTO>> GetAllAssociadoDTO()
         {
-            return from pessoa in _context.Pessoas
-                   select new AssociadoDTO
-                   {
-                       Id = pessoa.Id,
-                       Nome = pessoa.Nome,
-                       Ativo = pessoa.Ativo
-                   };
+            var query = from pessoa in _context.Pessoas
+                        where pessoa.IdPapelGrupo == 1
+                        select new AssociadoDTO
+                        {
+                            Id = pessoa.Id,
+                            Nome = pessoa.Nome,
+                            Ativo = pessoa.Ativo
+                        };
+
+            return await query.AsNoTracking().ToListAsync();
         }
+
         public IEnumerable<Papelgrupo> GetAllPapelGrupo()
         {
             return _context.Papelgrupos.AsNoTracking();


### PR DESCRIPTION
# O que foi feito
- Removido Input select de Colaborador (Id agora vem do usuário identity)
- Adicionado estilo para página de movimentar instrumento
- Adicionado notificações para excluir e notificar movimentações

## Como testar
- Acesse o sistema com CPF e Senha de um Administrador do Grupo
- Caso não tenha um acesso de Adm Grupo, acesse como Adm do Sistema
- Clique em Administradores no Grupo Musical
- Adicione um Administrador do Grupo Musical (A senha para acesso por enquanto é o CPF)
- Movimente um instrumento musical (Cadastre um se não tiver)
- Tente excluir todas as movimentações (O sistema bloqueia remover movimentação de empréstimo com instrumento não devolvido)
- Envie um e-mail para o associado clicando em "Reenviar"

## Tela
![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/69280619/dc32b790-4b16-43c8-bc75-4e2967f55210)

## Tela para Tablet
![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/69280619/53d969e6-cb53-4d1f-9e3e-108c3330240b)

## Tela para smpartphone
![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/69280619/63afabd2-9e85-49f0-9b73-1361a53968a2)
