### PR TITLE
Correção de bug ao adicionar um adm de grupo que já era associado

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/HomeController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/HomeController.cs
@@ -39,7 +39,8 @@ namespace GestaoGrupoMusicalWeb.Controllers
             else if(User.IsInRole("ADMINISTRADOR SISTEMA"))
             {
                 return RedirectToAction(nameof(Index), "GrupoMusical");
-            }else if(User.IsInRole("ADMINISTRADOR GRUPO"))
+            }
+            else if(User.IsInRole("ADMINISTRADOR GRUPO"))
             {
                 return RedirectToAction(nameof(Index), "InstrumentoMusical");
             }

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -345,13 +345,14 @@ namespace Service
                     if (user != null)
                     {
                         await _userManager.RemoveFromRoleAsync(user, "ADMINISTRADOR GRUPO");
+                        await _userManager.AddToRoleAsync(user, "ASSOCIADO");
+
+                        pessoa.IdPapelGrupo = 1;
+
+                        _context.Pessoas.Update(pessoa);
+
+                        await _context.SaveChangesAsync();
                     }
-                    pessoa.IdPapelGrupo = 1;
-
-                    _context.Pessoas.Update(pessoa);
-
-                    await _context.SaveChangesAsync();
-
                     return true;
                 }
                 return false;

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -251,6 +251,7 @@ namespace Service
                         {
                             await _roleManager.CreateAsync(new IdentityRole("ADMINISTRADOR GRUPO"));
                         }
+                        await _userManager.RemoveFromRoleAsync(user, "ASSOCIADO");
                         await _userManager.AddToRoleAsync(user, "ADMINISTRADOR GRUPO");
                     }
                     //caso não user identity exista

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -279,7 +279,12 @@ namespace Service
 
                     //id para adm de grupo == 3
                     pessoaF.IdPapelGrupo = 3;
-                    if(await Edit(pessoaF) != 200)
+                    try
+                    {
+                        _context.Pessoas.Update(pessoaF);
+                        await _context.SaveChangesAsync();
+                    }
+                    catch 
                     {
                         await transaction.RollbackAsync();
                         return 500;//o usuario já possui cadastro em um grupo musical, não foi possiveç alterar ele para adm grupo musical


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Correção ao promovar um associado ja cadastrado no sistema a administrador de grupo musical

## Foi Feito
- [x] Removido role "Associado" antes de promover a administrador de grupo
- [x] Removido role "ADMINISTRADOR GRUPO" antes de promover a associado
- [x] Update feito dentro do próprio método (antes era feito no edit)

## Mudanças Que Não Estavam Previstas
- [x] Corrigido identação em controller

## Como Testar
Adicione um associado através do perfil de um administrador de grupo musical, pois o associado precisa pertencer ao grupo o qual será promovido, e depois tente-o promover a administrador de grupo musica com o perfil de adm de sistema.

OBS: Coloque o mesmo cpf do associado, a verificação é feita pelo cpf.

## Prints
![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/a8ff022e-6370-40c7-a155-80f652357574)

![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/73c00455-7af8-4647-aeea-88e72bd96cd0)

![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/bab9b540-83c4-4b0a-8c97-9a73bedf796e)




**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
