### PR TITLE
Alinhamento de botões - Index - Grupo Musical

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/GrupoMusical/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/GrupoMusical/Index.cshtml
@@ -36,12 +36,11 @@
                     <td>
                         @Html.DisplayFor(modelItem => item.Name)
                     </td>
-
-                    <td class="d-flex justify-content-between border-0 flex-wrap py-3">
-                        <a role="button" class="btn btn-secondary btn-sm mb-xl-0 mb-2 " asp-controller="GrupoMusical" asp-action="Edit" asp-route-id="@item.Id"><i class="fa-solid fa-pen-to-square"> </i> Editar</a>
-                        <a role="button" class="btn btn-secondary btn-sm mb-xl-0 mb-2" asp-controller="GrupoMusical" asp-action="Details" asp-route-id="@item.Id"><i class="fa-solid fa-file"> </i> Detalhes</a>
-                        <a role="button" class="btn btn-secondary btn-sm mb-xl-0 mb-2" asp-controller="GrupoMusical" asp-action="Delete" asp-route-id="@item.Id"><i class="fa-solid fa-xmark"> </i> Excluir</a>
-                        <a role="button" class="btn btn-secondary btn-sm mb-xl-0 mb-2" asp-controller="AdministradorGrupoMusical" asp-action="Index" asp-route-id="@item.Id"><i class="fa-solid fa-lock-open"></i> Administradores</a>
+                        <td class="d-flex flex-wrap border-0 align-items-center">
+                            <a role="button" class="btn btn-secondary btn-sm  m-2 " asp-controller="GrupoMusical" asp-action="Edit" asp-route-id="@item.Id"><i class="fa-solid fa-pen-to-square"> </i> Editar</a>
+                            <a role="button" class="btn btn-secondary btn-sm  m-2" asp-controller="GrupoMusical" asp-action="Details" asp-route-id="@item.Id"><i class="fa-solid fa-file"> </i> Detalhes</a>
+                            <a role="button" class="btn btn-secondary btn-sm  m-2" asp-controller="GrupoMusical" asp-action="Delete" asp-route-id="@item.Id"><i class="fa-solid fa-xmark"> </i> Excluir</a>
+                            <a role="button" class="btn btn-secondary btn-sm  m-2" asp-controller="AdministradorGrupoMusical" asp-action="Index" asp-route-id="@item.Id"><i class="fa-solid fa-lock-open"></i> Administradores</a>
                     </td>
                 </tr>
             }


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Tirar a configuração justify-content-beetween da tag que engloba os botões relacionados a cada um dos Grupos Musicais.

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x] Remoção do justify-content-beetween da tag com os botões.
- [x] Uso de configuração similar ao da Index de Instrumento Musical na tag com os botões.

## Mudanças Que Não Estavam Previstas

## Como Testar
Fazer o login no sistema como Administrador do Sistema. Os botões estão localizados na página inicial. Para testá-los basta inspecionar a página e verificar a responsidade. Além disso, é desejável checar o código alterado.

## Prints
![image](https://github.com/marcosdosea/GestaoGrupoMusical/assets/62863349/be617447-f021-4c5f-9a6d-cfb5a087eac1)


**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
