### PR TITLE
Restrição para que somente o administrador do grupo possa acessar os instrumento do grupo

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/InstrumentoMusicalController.cs
@@ -47,6 +47,11 @@ namespace GestaoGrupoMusicalWeb.Controllers
         public async Task<ActionResult> Details(int id)
         {
             var instrumentoMusical = await _instrumentoMusical.Get(id);
+            if (Convert.ToInt32(User.FindFirst("IdGrupoMusical")?.Value) != instrumentoMusical?.IdGrupoMusical)
+            {
+                Notificar("<b>Instrumento não encontrado!</b>", Notifica.Alerta);
+                return RedirectToAction(nameof(Index));
+            }
             var instrumentoMusicalModel = _mapper.Map<InstrumentoMusicalViewModel>(instrumentoMusical);
             return View(instrumentoMusicalModel);
         }
@@ -102,6 +107,12 @@ namespace GestaoGrupoMusicalWeb.Controllers
         public async Task<ActionResult> Edit(int id)
         {
             var instrumentoMusical = await _instrumentoMusical.Get(id);
+
+            if (Convert.ToInt32(User.FindFirst("IdGrupoMusical")?.Value) != instrumentoMusical?.IdGrupoMusical)
+            {
+                Notificar("<b>Instrumento não encontrado!</b>", Notifica.Alerta);
+                return RedirectToAction(nameof(Index));
+            }
             var instrumentoMusicalModel = _mapper.Map<InstrumentoMusicalViewModel>(instrumentoMusical);
             if (instrumentoMusicalModel.Status != "EMPRESTADO")
             {
@@ -212,6 +223,11 @@ namespace GestaoGrupoMusicalWeb.Controllers
         {
             MovimentacaoInstrumentoViewModel movimentacaoModel = new();
             var instrumento = await _instrumentoMusical.Get(id);
+            if (Convert.ToInt32(User.FindFirst("IdGrupoMusical")?.Value) != instrumento?.IdGrupoMusical)
+            {
+                Notificar("<b>Instrumento não encontrado!</b>", Notifica.Alerta);
+                return RedirectToAction(nameof(Index));
+            }
             var movimentacao = await _movimentacaoInstrumento.GetEmprestimoByIdInstrumento(id);
             if (instrumento.Status.Equals("DANIFICADO"))
             {


### PR DESCRIPTION
…az parte do grupo especifico consiga fazer alteração em instrumento de outro grupo

<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
 Garantir ou verificar se o Instrumento retornado nos métodos Get fazem parte do Grupo Musical correto 

## Foi Feito
- [x] Foi utilizado o Convert.ToInt32(User.FindFirst("IdGrupoMusical")?.Value) para garantir que o Get seja sempre o do grupo específico 

## Como Testar
1 - Ter mais de um grupo musical. 
2 - Adicionar instrumentos a este grupo novo.
3 - Acessar Edit, Movimentar ou Details com os id de um instrumento ao qual não pertence ao mesmo grupo 

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
