### PR TITLE
Adicionar regra para não permitir que remova o único administrador do grupo

### DIFF
--- a/Codigo/Core/Service/IPessoaService.cs
+++ b/Codigo/Core/Service/IPessoaService.cs
@@ -62,7 +62,7 @@ namespace Core.Service
         /// HttpStatusCode.OK - Administrador removido com sucesso
         /// HttpStatusCode.NotFound - Administrador não encontrado
         /// HttpStatusCode.InternalServerError - Erro no servidor ou em alguma operação 
-        ///  return HttpStatusCode.NotAcceptable - Não permiter remover o unico administrador do grupo
+        ///  return HttpStatusCode.NotAcceptable - Não permitir remover o unico administrador do grupo
         /// </returns>
         Task<HttpStatusCode> RemoveAdmGroup(int id);
 

--- a/Codigo/Core/Service/IPessoaService.cs
+++ b/Codigo/Core/Service/IPessoaService.cs
@@ -54,7 +54,17 @@ namespace Core.Service
         /// </returns>
         Task<HttpStatusCode> AddAdmGroup(Pessoa pessoa);
         Task<IEnumerable<AdministradorGrupoMusicalDTO>> GetAllAdmGroup(int id);
-        Task<bool> RemoveAdmGroup(int id);
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns>
+        /// HttpStatusCode.OK - Administrador removido com sucesso
+        /// HttpStatusCode.NotFound - Administrador não encontrado
+        /// HttpStatusCode.InternalServerError - Erro no servidor ou em alguma operação 
+        ///  return HttpStatusCode.NotAcceptable - Não permiter remover o unico administrador do grupo
+        /// </returns>
+        Task<HttpStatusCode> RemoveAdmGroup(int id);
 
         Task<HttpStatusCode> ToCollaborator(int id, int idPapel);
         Task<HttpStatusCode> RemoveCollaborator(int id);

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/AdministradorGrupoMusicalController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/AdministradorGrupoMusicalController.cs
@@ -23,7 +23,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
 
         private readonly UserManager<UsuarioIdentity> _userManager;
 
-        public AdministradorGrupoMusicalController(IPessoaService pessoaService,IGrupoMusicalService grupoMusicalService,
+        public AdministradorGrupoMusicalController(IPessoaService pessoaService, IGrupoMusicalService grupoMusicalService,
                                                    IMapper mapper, UserManager<UsuarioIdentity> userManager)
         {
             _pessoaService = pessoaService;
@@ -43,7 +43,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
 
             administradorModel.ListaAdministrador = await _pessoaService.GetAllAdmGroup(id);
             var grupoMusical = await _grupoMusicalService.Get(id);
-            if(grupoMusical == null)
+            if (grupoMusical == null)
             {
                 return RedirectToAction(nameof(Index), "GrupoMusical");
             }
@@ -124,7 +124,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                         Notificar(mensagem, Notifica.Erro);
                         break;
                 }
-               
+
             }
             return RedirectToAction(nameof(Index), new { id = admViewModel.IdGrupoMusical });
         }
@@ -156,8 +156,30 @@ namespace GestaoGrupoMusicalWeb.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> Delete(int id, int idGrupoMusical)
         {
-            await _pessoaService.RemoveAdmGroup(id);
-            return RedirectToAction(nameof(Index), new { id= idGrupoMusical });
+            HttpStatusCode result = await _pessoaService.RemoveAdmGroup(id);
+            String mensagem = String.Empty;
+            switch (result)
+            {
+                case HttpStatusCode.OK:
+                    mensagem = "<b>Sucesso</b>! Administrador removido.";
+                    Notificar(mensagem, Notifica.Sucesso);
+                    break;
+
+                case HttpStatusCode.NotFound:
+                    mensagem = "<b>Erro</b>! Administrador não encontrado.";
+                    Notificar(mensagem, Notifica.Erro);
+                    break;
+                case HttpStatusCode.NotAcceptable:
+                    mensagem = "<b>Alerta</b>! Não é possível <b>remover</b> o único adminstrador do grupo.";
+                    Notificar(mensagem, Notifica.Alerta);
+                    break;
+                case HttpStatusCode.InternalServerError:
+                    mensagem = "<b>Erro</b>! Desculpe, ocorreu um erro durante a <b>Operação</b>.";
+                    Notificar(mensagem, Notifica.Erro);
+                    break;
+
+            }
+            return RedirectToAction(nameof(Index), new { id = idGrupoMusical });
         }
 
         public async Task<ActionResult> Notificar(int id)

--- a/Codigo/GestaoGrupoMusicalWeb/Views/AdministradorGrupoMusical/Delete.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/AdministradorGrupoMusical/Delete.cshtml
@@ -1,5 +1,5 @@
 ﻿@model GestaoGrupoMusicalWeb.Models.PessoaViewModel
-
+<partial name="_Notificar">
 @{
     ViewData["Title"] = "Remover Administrador";
 }

--- a/Codigo/Service/PessoaService.cs
+++ b/Codigo/Service/PessoaService.cs
@@ -335,33 +335,44 @@ namespace Service
             return await AdmGroupList.ToListAsync();
         }
 
-        public async Task<bool> RemoveAdmGroup(int id)
+        public async Task<HttpStatusCode> RemoveAdmGroup(int id)
         {
-            try
-            {
-                var pessoa = await _context.Pessoas.FindAsync(id);
-                if (pessoa != null)
+            var pessoa = await _context.Pessoas.FindAsync(id);
+            var lista = await GetAllAdmGroup(pessoa.IdGrupoMusical);
+            int count = lista.Count();
+            if(count > 1) {
+                try
                 {
-                    var user = await _userManager.FindByNameAsync(pessoa.Cpf);
-                    if (user != null)
+
+                    if (pessoa != null)
                     {
-                        await _userManager.RemoveFromRoleAsync(user, "ADMINISTRADOR GRUPO");
-                        await _userManager.AddToRoleAsync(user, "ASSOCIADO");
+                        var user = await _userManager.FindByNameAsync(pessoa.Cpf);
+                        if (user != null)
+                        {
+                            await _userManager.RemoveFromRoleAsync(user, "ADMINISTRADOR GRUPO");
+                            await _userManager.AddToRoleAsync(user, "ASSOCIADO");
 
-                        pessoa.IdPapelGrupo = 1;
+                            pessoa.IdPapelGrupo = 1;
 
-                        _context.Pessoas.Update(pessoa);
+                            _context.Pessoas.Update(pessoa);
 
-                        await _context.SaveChangesAsync();
+                            await _context.SaveChangesAsync();
+                        }
+                        return HttpStatusCode.OK;
                     }
-                    return true;
+                    return HttpStatusCode.NotFound;
                 }
-                return false;
+                catch
+                {
+                    return HttpStatusCode.InternalServerError;
+                }
+
             }
-            catch
+            else
             {
-                return false;
+                return HttpStatusCode.NotAcceptable;
             }
+
         }
 
         public async Task<HttpStatusCode> AddAssociadoAsync(Pessoa pessoa)


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Adicionar regra para não permitir que remova o único administrador do grupo

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x] Adição da regra de negócio para não permitir que remova o único administrador do grupo


## Mudanças Que Não Estavam Previstas
[Caso tenha feito alguma alteração extra que não estava originalmente planejada, descreva-as aqui. Use o checklist markdown como o exemplo abaixo]
- [x] Alteração do retorno do RemoveAdmGroup era bool mudei para httpstatuscode
- [x] Troca de retorno da função RemoveAdmGroup
- [x] Adição de notificação na tela quando remove um administrador do grupo 


## Como Testar
adicionar 2 ou mais administrador do grupo e em seguida remove-los

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
