### PR TITLE
Correção da localização da mensagem, quando não tem empréstimo ou devolução.

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/_TabelaDevolucaoFigurino.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/_TabelaDevolucaoFigurino.cshtml
@@ -37,11 +37,11 @@
                 </tr>
             }
         </tbody>
-        @if (!Model.Any())
-        {
-            <p class="text-center mt-4 mb-0">Desculpe, nenhuma <b>Devolução</b> encontrada :(</p>
-        }
     </table>
+    @if (!Model.Any())
+    {
+        <p class="text-center mt-4 mb-0">Desculpe, nenhuma <b>Devolução</b> encontrada :(</p>
+    }
     <div class="modal fade" id="associadoDevolucaoModal" tabindex="-1" aria-labelledby="associadoDevolucaoLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/_TabelaFigurinoEntregue.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/_TabelaFigurinoEntregue.cshtml
@@ -37,11 +37,11 @@
                 </tr>
             }
         </tbody>
-        @if (!Model.Any())
-        {
-            <p class="text-center mt-4 mb-0">Desculpe, nenhuma <b>Entregar</b> encontrada :(</p>
-        }
     </table>
+    @if (!Model.Any())
+    {
+        <p class="text-center mt-4 mb-0">Desculpe, nenhuma <b>Entrega</b> encontrada :(</p>
+    }
     <div class="modal fade" id="associadoEntregueModal" tabindex="-1" aria-labelledby="associadoDevolucaoLabel" aria-hidden="true">
         <div class="modal-dialog">
             <div class="modal-content">


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Correção da localização da mensagem, quando não tem empréstimo ou devolução. Estava acima da tabela agora está abaixo.
## Foi Feito
- [x] Correção da localização da mensagem, quando não tem `empréstimo`. Estava acima da tabela agora está abaixo.
- [x] Correção da localização da mensagem, quando não tem  `devolução`. Estava acima da tabela agora está abaixo.
- [x] Correção do verbo `Entregar` para `Entrega`


## Como Testar
Verificar se a mensagem fica abaixo da tabela quando não a movimentações relacionada a empréstimo ou devolução, na view de figurino para Administrador de grupo.




**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
