### PR TITLE
Todos os Displays agora estao padronizados

### DIFF
--- a/Codigo/Core/DTO/EventoDTO.cs
+++ b/Codigo/Core/DTO/EventoDTO.cs
@@ -24,22 +24,22 @@ namespace Core.DTO
     {
         public int Id { get; set; }
 
-        [DisplayName("Data hora início")]
+        [Display(Name = "Data hora início")]
         public DateTime DataHoraInicio { get; set; }
 
-        [DisplayName("Data hora fim")]
+        [Display(Name = "Data hora fim")]
         public DateTime DataHoraFim { get; set; }
 
-        [DisplayName("Regente")]
+        [Display(Name = "Regente")]
         public IEnumerable<string>? Regente { get; set; }
 
-        [DisplayName("Figurino")]
+        [Display(Name = "Figurino")]
         public IEnumerable<string>? Figurino { get; set; }
 
-        [DisplayName("Local")]
+        [Display(Name = "Local")]
         public string? Local { get; set; }
 
-        [DisplayName("Instrumento")]
+        [Display(Name = "Instrumento")]
         public IEnumerable<Tipoinstrumento>? Instrumento { get; set; }
 
     }


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Padronizar os Displays de EventoDTO.

## Foi Feito
- [x] Todos os Displays estão iguais.

## Prints
![image](https://github.com/user-attachments/assets/b423f6e5-7713-4b7d-a3fa-40c307bdf8c0)
![image](https://github.com/user-attachments/assets/34898448-b019-45e0-a047-420caa4b0aa9)

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
