### PR TITLE
614 implementar tabela instrumento planejado evento

### DIFF
--- a/Codigo/Core/DTO/GerenciarInstrumentoEventoDTO.cs
+++ b/Codigo/Core/DTO/GerenciarInstrumentoEventoDTO.cs
@@ -25,5 +25,7 @@ namespace Core.DTO
         [Display(Name = "Instrumento")]
         public IEnumerable<Tipoinstrumento>? Instrumento { get; set; }
 
+        [Display(Name = "Instrumento")]
+        public string NomeInstrumento { get; set; } = string.Empty;
     }
 }

--- a/Codigo/Core/DTO/GerenciarInstrumentoEventoDTO.cs
+++ b/Codigo/Core/DTO/GerenciarInstrumentoEventoDTO.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace Core.DTO
 {

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -214,6 +214,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
 
             if (figurinosDropdown == null || !figurinosDropdown.Any())
             {
+
                 Notificar("É necessário cadastrar um Figurino para então cadastrar um Evento Musical.", Notifica.Informativo);
                 return RedirectToAction(nameof(Index));
             }

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -218,7 +218,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                 Notificar("É necessário cadastrar um Figurino para então cadastrar um Evento Musical.", Notifica.Informativo);
                 return RedirectToAction(nameof(Index));
             }
-            var evento = _evento.Get(idGrupoMusical);
+            var evento = _evento.Get(id);
             EventoViewModel eventoView = _mapper.Map<EventoViewModel>(evento);
 
             InstrumentoMusicalViewModel instrumentoMusicalViewModel = new InstrumentoMusicalViewModel();

--- a/Codigo/GestaoGrupoMusicalWeb/Models/EventoViewModel.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Models/EventoViewModel.cs
@@ -73,7 +73,8 @@ namespace GestaoGrupoMusicalWeb.Models
 
         public SelectList? ListaPessoa { get; set; }
 
-    } public class GerenciarInstrumentoEventoViewModel
+    }
+    public class GerenciarInstrumentoEventoViewModel
     {
         public int Id { get; set; }
         public int IdGrupoMusical { get; set; }

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
@@ -1,4 +1,4 @@
-﻿@model GestaoGrupoMusicalWeb.Models.GerenciarInstrumentoEventoViewModel;
+﻿@model GestaoGrupoMusicalWeb.Models.GerenciarInstrumentoEventoViewModel
 @{
     ViewData["Title"] = "Gerenciar Instrumento Evento";
     ViewData["Evento"] = "Eventos";

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
@@ -1,4 +1,4 @@
-﻿@model GestaoGrupoMusicalWeb.Models.GerenciarInstrumentoEventoViewModel
+﻿@model GestaoGrupoMusicalWeb.Models.GerenciarInstrumentoEventoViewModel;
 @{
     ViewData["Title"] = "Gerenciar Instrumento Evento";
     ViewData["Evento"] = "Eventos";
@@ -13,7 +13,7 @@
                 <ol class="breadcrumb px-3">
                     <strong>
                         <a class="text-danger text-opacity-75" asp-action="Index">@ViewData["Evento"]</a>
-                        <spn class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["GerenciarInstrumento"]</spn>
+                        <spn class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["GerenciarInstrumentoEvento"]</spn>
                     </strong>
                 </ol>
             </nav>
@@ -84,7 +84,7 @@
             </div>
             <br />
             <br />
-          
+
             <partial name="_TabelaGerenciarInstrumento">
 
                 <div class="row">
@@ -92,9 +92,7 @@
                         <a class="btn btn-outline-secondary col-lg-2 mt-3 me-lg-3 btn-" asp-controller="Evento" asp-action="Index">Voltar</a>                        
                     </div>
                 </div>
-        </div>
-       
-                        
+        </div>                               
     </div>
 
     @section Header {

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
@@ -23,12 +23,12 @@
                     <div class="row">
                         <div class="form-group col-xxl-4">
                             <label asp-for="DataHoraInicio" class="control-label"></label>
-                            <input asp-for="DataHoraInicio" class="form-control" />
+                        <input asp-for="DataHoraInicio" class="form-control" readonly />
                             <span asp-validation-for="DataHoraInicio" class="text-danger"></span>
                         </div>
                         <div class="form-group col-xxl-4">
                             <label asp-for="DataHoraFim" class="control-label"></label>
-                            <input asp-for="DataHoraFim" class="form-control" />
+                        <input asp-for="DataHoraFim" class="form-control" readonly />
                             <span asp-validation-for="DataHoraFim" class="text-danger"></span>
                         </div>
                     </div>
@@ -37,7 +37,7 @@
                     <div class="row col-xl">
                         <div class="form-group">
                             <label asp-for="IdRegentes" class="control-label"></label>
-                            <select asp-for="IdRegentes" asp-items="@Model.ListaPessoa" class="form-select">
+                        <select asp-for="IdRegentes" asp-items="@Model.ListaPessoa" class="form-select" readonly>
                                 <option value=""></option>
                             </select>
                             <span asp-validation-for="IdRegentes" class="text-danger"></span>
@@ -52,7 +52,7 @@
 
                 <div class="form-group">
                     <label asp-for="IdFigurinoSelecionado" class="control-label"></label>
-                    <select asp-items="@Model.FigurinoList" asp-for="IdFigurinoSelecionado" class="form-select" disabled></select>
+                    <select asp-items="@Model.FigurinoList" asp-for="IdFigurinoSelecionado" class="form-select" readonly></select>
                     <span asp-validation-for="IdFigurinoSelecionado" class="text-danger"></span>
                 </div>
             </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarInstrumentoEvento.cshtml
@@ -85,7 +85,7 @@
             <br />
             <br />
 
-            <partial name="_TabelaGerenciarInstrumento">
+            <partial name="_TabelaGerenciarInstrumento" model="@Model.IdRegentes">
 
                 <div class="row">
                     <div class="d-flex justify-content-lg-end flex-column-reverse flex-lg-row">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Index.cshtml
@@ -86,7 +86,7 @@
 
                                 return '<a class="btn btn btn-secondary btn-sm  m-2" href="/Evento/Edit/' + full.id + '"><i class="fa-solid fa-pen-to-square"> </i> Editar</a> ' +
                                     '<a onclick="showConfirmationModal(' + full.id + ')" class="btn btn-sm btn-secondary" role="button"><i class="fa-solid fa-xmark"></i> Excluir</a> ' +
-                                    '<a class="btn btn btn-secondary btn-sm  m-2" href="/Evento/GerenciarInstrumentoEvento/' + full.id + '"><i class="fa-solid fa-pen-to-square"> </i> Instrumentos</a> ' +
+                                    '<a class="btn btn btn-secondary btn-sm  m-2" href="/Evento/GerenciarInstrumentoEvento/' + full.id + '"><i class="fa-solid fa-pen-to-square"> </i> Instrumentos</a> <br>' +
                                     '<a class="btn btn btn-secondary btn-sm  m-2"><i class="fa-solid fa-pen-to-square"> </i> Solicitações</a> ' +
                                     '<a class="btn btn btn-secondary btn-sm  m-2"><i class="fa-solid fa-pen-to-square"> </i> Frequência</a> ' +
                                     '<a onclick="showConfirmationModalNotificar(' + full.id + ')" class="btn btn btn-secondary btn-sm  m-2" "><i class="fa-solid fa-envelope"> </i> Notificar</a> ';

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Index.cshtml
@@ -86,7 +86,7 @@
 
                                 return '<a class="btn btn btn-secondary btn-sm  m-2" href="/Evento/Edit/' + full.id + '"><i class="fa-solid fa-pen-to-square"> </i> Editar</a> ' +
                                     '<a onclick="showConfirmationModal(' + full.id + ')" class="btn btn-sm btn-secondary" role="button"><i class="fa-solid fa-xmark"></i> Excluir</a> ' +
-                                    '<a class="btn btn btn-secondary btn-sm  m-2" href="/Evento/GerenciarInstrumentoEvento/' + full.id + '><i class="fa-solid fa-pen-to-square"> </i> Instrumentos</a> <br>' +
+                                    '<a class="btn btn btn-secondary btn-sm  m-2" href="/Evento/GerenciarInstrumentoEvento/' + full.id + '"><i class="fa-solid fa-pen-to-square"> </i> Instrumentos</a> ' +
                                     '<a class="btn btn btn-secondary btn-sm  m-2"><i class="fa-solid fa-pen-to-square"> </i> Solicitações</a> ' +
                                     '<a class="btn btn btn-secondary btn-sm  m-2"><i class="fa-solid fa-pen-to-square"> </i> Frequência</a> ' +
                                     '<a onclick="showConfirmationModalNotificar(' + full.id + ')" class="btn btn btn-secondary btn-sm  m-2" "><i class="fa-solid fa-envelope"> </i> Notificar</a> ';

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/_TabelaGerenciarInstrumento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/_TabelaGerenciarInstrumento.cshtml
@@ -5,10 +5,10 @@
         <thead>
             <tr class="bg-danger bg-opacity-75 text-white">
                 <th>
-                    @Html.DisplayNameFor(model => model.Instrumento);
+                    @Html.DisplayNameFor(model => model.Instrumento)
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Local);
+                    @Html.DisplayNameFor(model => model.Local)
                 </th>
                 <th>
                     Solicitados

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/_TabelaGerenciarInstrumento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/_TabelaGerenciarInstrumento.cshtml
@@ -41,9 +41,7 @@
                                onclick="showModal(' +"_notificar")', 'notificarMovimentacaoModal')">
                                 <i class="fa-solid fa-envelope"></i>
                                 Notificar
-                            </a>
-                        
-                        
+                            </a>                                                
                             <a role="button" class="btn btn-sm btn-secondary"
                                data-bs-toggle="modal" data-bs-target="#excluirMovimentacaoModal"
                                onclick="showModal('+ "_delete")', 'excluirMovimentacaoModal')">


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Criar a View Gerenciar Instrumento Musical em Eventos.

## Foi Feito

- [x] View com informações sobre um Eventos específico já cadastrado na base de dados.


## Como Testar
Acessar o sistema Gestão Grupo Musical, acessar o menu Evento (esquerda da aplicação), em seguida localizar o evento que deseja gerenciar os instrumentos a serem utilizados no evento, clicar no botão instrumentos, em seguida irá exibir a janela com dados do eventos, e campo para adicionar os instrumentos. **Ainda não é possível adicionar instrumentos.**

## Prints
![image](https://github.com/user-attachments/assets/b0306bdd-9251-4b08-a692-8eb9aed60d3a)



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
