### PR TITLE
Marca presença de todos os associados ao carregar página de frequência

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EnsaioController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EnsaioController.cs
@@ -277,8 +277,9 @@ namespace GestaoGrupoMusicalWeb.Controllers
             int idGrupoMusical = await _grupoMusical.GetIdGrupo(User.Identity.Name);
 
             var listaAssociadosAtivos = _ensaioService.GetAssociadoAtivos(id);
-            foreach(AssociadoDTO la in listaAssociadosAtivos)
+            foreach (AssociadoDTO la in listaAssociadosAtivos)
             {
+                la.Presente = 1; 
                 la.PresenteModel = la.Presente;
                 la.JustificativaAceitaModel = la.JustificativaAceita;
             }


### PR DESCRIPTION
Pré-selecionar a presença para todos os associados

Essa alteração marca todos os associados como presentes por padrão na página de registro de frequência de ensaio.