### PR TITLE
feat(sessoes): remover opção "Exibir → Todos" das páginas iniciais

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/Index.cshtml
@@ -57,8 +57,8 @@
                     "orderMulti": false, // for disable multiple column at once
                     "pageLength": 5,
                     "lengthMenu": [
-                        [5, 10, 20, -1],
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20],
+                        [5, 10, 20]
                     ],
                     "ajax": {
                         "url": "/Ensaio/GetDataPage",

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Index.cshtml
@@ -43,8 +43,8 @@
                     "orderMulti": false, // for disable multiple column at once
                     "pageLength": 5,
                     "lengthMenu": [
-                        [5, 10, 20, -1],
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20],
+                        [5, 10, 20]
                     ],
                     "ajax": {
                         "url": "/Evento/GetDataPage",

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/Index.cshtml
@@ -41,8 +41,8 @@
                     "orderMulti": false, // for disable multiple column at once
                     "pageLength": 5,
                     "lengthMenu": [
-                        [5, 10, 20, -1],
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20],
+                        [5, 10, 20]
                     ],
                     "ajax": {
                         "url": "/Figurino/GetDataPage",

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Financeiro/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Financeiro/Index.cshtml
@@ -13,7 +13,7 @@
 
 
 <partial name="_Notificar">
-
+    
     <div class="d-flex justify-content-between align-items-center">
 
         <h5>@ViewData["Title"]</h5>
@@ -106,9 +106,9 @@
 
                     "lengthMenu": [
 
-                        [5, 10, 20, -1],
+                        [5, 10, 20],
 
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20]
 
                     ],
 

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Informativo/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Informativo/Index.cshtml
@@ -38,8 +38,8 @@
                         "orderMulti": false, // for disable multiple column at once
                         "pageLength": 5,
                         "lengthMenu": [
-                            [5, 10, 20, -1],
-                            [5, 10, 20, "Todos"]
+                            [5, 10, 20],
+                            [5, 10, 20]
                         ],
                         "ajax": {
                             "url": "/Informativo/GetDataPage",

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Index.cshtml
@@ -47,8 +47,8 @@
                     "orderMulti": false, // for disable multiple column at once
                     "pageLength": 5,
                     "lengthMenu": [
-                        [5, 10, 20, -1],
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20],
+                        [5, 10, 20]
                     ],
                     "ajax": {
                         "url": "/InstrumentoMusical/GetDataPage",

--- a/Codigo/GestaoGrupoMusicalWeb/Views/MaterialEstudo/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/MaterialEstudo/Index.cshtml
@@ -43,8 +43,8 @@
                     "orderMulti": false, // for disable multiple column at once
                     "pageLength": 5,
                     "lengthMenu": [
-                        [5, 10, 20, -1],
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20],
+                        [5, 10, 20]
                     ],
                     "ajax": {
                         "url": "/MaterialEstudo/GetDataPage",

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Index.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Pessoa/Index.cshtml
@@ -39,8 +39,8 @@
                     "orderMulti": false, // for disable multiple column at once
                     "pageLength": 5,
                     "lengthMenu": [
-                        [5, 10, 20, -1],
-                        [5, 10, 20, "Todos"]
+                        [5, 10, 20],
+                        [5, 10, 20]
                     ],
                     "ajax": {
                         "url": "/Pessoa/GetDataPage",


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Remover opção ‘Exibir → Todos’ das páginas iniciais das sessões para melhorar desempenho.

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [ ] Item 1
- [ ] Item 2 
- [X] Item 8

## Mudanças Que Não Estavam Previstas
[Caso tenha feito alguma alteração extra que não estava originalmente planejada, descreva-as aqui. Use o checklist markdown como o exemplo abaixo]
- [ ] Item 1
- [ ] Item 2 
- [ ] Item 3

## Como Testar
Abrir página inicial de cada sessão, Exibir → Todos e verificar se opção "Todos" é inexistente. 
-Ensaios
-Eventos
-Associados
-Financeiro
-Instrumentos
-Figurinos
-Material de Estudos
-Informativos

## Prints
<img width="1849" height="883" alt="image" src="https://github.com/user-attachments/assets/760b190b-879f-4dc6-b787-4c7b0789a1df" />




