### PR TITLE
fix: permitir valor decimal e ajustar campos de data no novo pagamento

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Models/FinanceiroCreateViewModel.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Models/FinanceiroCreateViewModel.cs
@@ -27,7 +27,7 @@ namespace GestaoGrupoMusicalWeb.Models
         [Required(ErrorMessage = "O valor é obrigatório")]
         [Range(0.01, 99999999.99, ErrorMessage = "O valor deve ser maior que zero e ter até duas casas decimais.")]
         [RegularExpression(@"^\d{1,8}(\.\d{1,2})?$", ErrorMessage = "O valor deve ter até 8 dígitos inteiros e 2 casas decimais.")]
-
+        
         public decimal? Valor { get; set; }
         public int IdGrupoMusical { get; set; }
     }

--- a/Codigo/GestaoGrupoMusicalWeb/Program.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Program.cs
@@ -5,6 +5,7 @@ using Service;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
 using GestaoGrupoMusicalWeb.Helpers;
+using System.Globalization;
 
 namespace GestaoGrupoMusicalWeb
 {
@@ -13,6 +14,27 @@ namespace GestaoGrupoMusicalWeb
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
+
+            // 1. Define a cultura base como pt-BR
+            var cultureInfo = new CultureInfo("pt-BR");
+
+            // 2. FORÇA o separador decimal a ser o PONTO ('.')
+            //    Isso garante que o Model Binder (que recebe 50.5 do front-end) 
+            //    o interprete corretamente como 50.5, resolvendo o problema de salvar 505.
+            cultureInfo.NumberFormat.NumberDecimalSeparator = ".";
+            cultureInfo.NumberFormat.CurrencyDecimalSeparator = ".";
+
+            // 3. Aplica essa configuração ao thread padrão
+            CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+            CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
+
+            // 4. Configura o RequestLocalizationOptions para toda a aplicação
+            builder.Services.Configure<Microsoft.AspNetCore.Builder.RequestLocalizationOptions>(options =>
+            {
+                options.DefaultRequestCulture = new Microsoft.AspNetCore.Localization.RequestCulture(culture: cultureInfo, uiCulture: cultureInfo);
+                options.SupportedCultures = new[] { cultureInfo };
+                options.SupportedUICultures = new[] { cultureInfo };
+            });
 
             // Add services to the container.
             builder.Services.AddControllersWithViews();
@@ -82,7 +104,7 @@ namespace GestaoGrupoMusicalWeb
             builder.Services.AddScoped<IMovimentacaoInstrumentoService, MovimentacaoInstrumentoService>();
             builder.Services.AddScoped<IMovimentacaoFigurinoService, MovimentacaoFigurinoService>();
             builder.Services.AddScoped<IUserClaimsPrincipalFactory<UsuarioIdentity>, ApplicationUserClaims>();
-            
+
             var app = builder.Build();
 
             // Configure the HTTP request pipeline.
@@ -95,6 +117,9 @@ namespace GestaoGrupoMusicalWeb
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();
+
+            // NOVO: Aplica as configurações de localização (incluindo o separador decimal)
+            app.UseRequestLocalization();
 
             app.UseRouting();
 

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Financeiro/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Financeiro/Create.cshtml
@@ -29,18 +29,18 @@
         <div class="row mb-4">
             <div class="form-group " style="width: 250px;">
                 <label asp-for="DataInicio" style="width: 150px;" class="control-label"></label>
-                <input asp-for="DataInicio" class="form-control" readonly />
+                <input asp-for="DataInicio" type = "date" class="form-control" readonly />
                 <span asp-validation-for="DataInicio" class="text-danger"></span>
             </div>
             <div class="form-group " style="width: 250px;">
                 <label asp-for="DataFim" class="control-label"></label>
-                <input asp-for="DataFim" class="form-control" />
+                <input asp-for="DataFim" type="date" max="9999-12-31" class="form-control" />
                 <span asp-validation-for="DataFim" class="text-danger"></span>
             </div>
         </div>
         <div class="form-group mb-5" style="width: 200px;">
             <label asp-for="Valor" class="control-label"></label>
-            <input asp-for="Valor" type="number" inputmode="decimal" class="form-control" />
+            <input asp-for="Valor" type="text" inputmode="decimal" class="form-control" id="valorPagamento" />
             <span asp-validation-for="Valor" class="text-danger"></span>
         </div>
         <div class="container">
@@ -88,25 +88,61 @@
             </div>
         </div>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-validate/1.19.5/localization/messages_pt_BR.min.js"></script>
 
-    <script>
-        function updateCharacterDescricao() {
-            var textArea = document.getElementById('descricaoTextArea');
-            var charCount = textArea.value.length;
-            var charLimitFromGrupoMusical = textArea.maxLength;
-            document.getElementById('descricaoCount').innerText = charCount + '/' + charLimitFromGrupoMusical;
-        }
+<script>
+    
+    function updateCharacterDescricao() {
+        var textArea = document.getElementById('descricaoTextArea');
+        var charCount = textArea.value.length;
+        var charLimitFromGrupoMusical = textArea.maxLength;
+        document.getElementById('descricaoCount').innerText =
+            charCount + '/' + charLimitFromGrupoMusical;
+    }
 
-        document.addEventListener('DOMContentLoaded', function () {
-            updateCharacterDescricao();
+    document.addEventListener('DOMContentLoaded', function () {
+        updateCharacterDescricao();
+
+        const form = document.getElementById('formCreate');
+        const valorInput = document.getElementById('valorPagamento');
+
+        form.addEventListener('submit', function (event) {
+            
+            valorInput.value = valorInput.value.replace(/,/g, '.');
         });
+    });
 
-            function abrirModal() {
-            var modal = new bootstrap.Modal(document.getElementById('modalNotificar'));
-            modal.show();
+   
+    document.getElementById("valorPagamento").addEventListener("input", function () {
+        let valor = this.value;
+
+        // Troca toda vírgula (,) por ponto (.) IMEDIATAMENTE.
+        // Isso resolve o erro de validação do front-end que espera o ponto.
+        valor = valor.replace(/,/g, '.');
+
+        valor = valor.replace(/[^0-9.]/g, '');
+
+        // Garante que haja no máximo um ponto decimal
+        const partes = valor.split('.');
+        if (partes.length > 2) {
+
+            valor = partes[0] + '.' + partes.slice(1).join('');
         }
 
-    </script>
+        // Se a parte decimal tiver mais de 2 dígitos, trunca (opcional, mas recomendado para o Regex)
+        if (partes.length > 1 && partes[1].length > 2) {
+             partes[1] = partes[1].substring(0, 2);
+             valor = partes.join('.');
+        }
+
+        this.value = valor;
+    });
+
+    function abrirModal() {
+        var modal = new bootstrap.Modal(document.getElementById('modalNotificar'));
+        modal.show();
+    }
+</script>
 
     @if (TempData["MostrarModal"] != null)
     {


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Campos de Data (Data Início e Data Fim)
Problema: O input de data exibe controles de hora e, em alguns casos, permite mais de 4 dígitos no ano.

Campo "Valor (R$)"
Problema: Sistema deve permitir valores em decimal, (padrão brasileiro).

Remover input (hora) de 'Data inicio e Data Final'
Corrigir input (data) -> 'Ano' deve permite apenas 4 dígitos
Corrigir input (Valor) -> deve permitir decimal e padrão brasileiro.
Corrigir input (Valor) ->usar campo que não apresente setas de acréscimo e decréscimo no mesmo.

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [ ] Item 1
- [ ] Item 2 
- [x] Item 3

## Mudanças Que Não Estavam Previstas
[Caso tenha feito alguma alteração extra que não estava originalmente planejada, descreva-as aqui. Use o checklist markdown como o exemplo abaixo]
- [x] Item 1
- [ ] Item 2 
- [ ] Item 3

## Como Testar
Sessão Financeiro > Novo Pagamento
preencher campos, pagamento com valor decimal.
verificar se ano preenche apenas com 4 digitos.
verificar no input 'Data inicio, Data final' foi removido a campo 'hora'.


## Prints
<img width="1852" height="844" alt="image" src="https://github.com/user-attachments/assets/5d6556ef-8ce4-424e-a144-98a5307b1cc0" />



