### PR TITLE
fix(Ensaio/Evento/Instrumento/Figurino/Financeiro): limitar entrada do campo de data a 4 dígitos para o ano.

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/Create.cshtml
@@ -16,7 +16,7 @@
                         <spn class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["Create"]</spn>
                     </strong>
                 </ol>
-            </nav>
+            </nav>  
             <hr />
             <br />
             <form id="formCreate" asp-action="Create">
@@ -24,12 +24,12 @@
                     <div class="row">
                         <div class="form-group col-xl-4">
                             <label asp-for="DataHoraInicio" class="control-label"></label>
-                            <input asp-for="DataHoraInicio" class="form-control" />
+                            <input asp-for="DataHoraInicio" max="9999-12-31T23:59" class="form-control" />
                             <span asp-validation-for="DataHoraInicio" class="text-danger"></span>
                         </div>
                         <div class="form-group col-xl-4">
                             <label asp-for="DataHoraFim" class="control-label"></label>
-                            <input asp-for="DataHoraFim" class="form-control" />
+                            <input asp-for="DataHoraFim" max="9999-12-31T23:59" class="form-control" />
                             <span asp-validation-for="DataHoraFim" class="text-danger"></span>
                         </div>
                         <div class="form-group col-xl">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/Edit.cshtml
@@ -39,12 +39,12 @@
                             <div class="row">
                                 <div class="form-group col-xxl-4">
                                     <label asp-for="DataHoraInicio" class="control-label"></label>
-                                    <input asp-for="DataHoraInicio" class="form-control" />
+                                    <input asp-for="DataHoraInicio" max="9999-12-31T23:59" class="form-control" />
                                     <span asp-validation-for="DataHoraInicio" class="text-danger"></span>
                                 </div>
                                 <div class="form-group col-xxl-4">
                                     <label asp-for="DataHoraFim" class="control-label"></label>
-                                    <input asp-for="DataHoraFim" class="form-control" />
+                                    <input asp-for="DataHoraFim" max="9999-12-31T23:59" class="form-control" />
                                     <span asp-validation-for="DataHoraFim" class="text-danger"></span>
                                 </div>
                                 <div class="form-group col-xl">

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Create.cshtml
@@ -24,12 +24,12 @@
                     <div class="row">
                         <div class="form-group col-xxl-4">
                             <label asp-for="DataHoraInicio" class="control-label"></label>
-                            <input asp-for="DataHoraInicio" class="form-control" />
+                            <input asp-for="DataHoraInicio" max="9999-12-31T23:59" class="form-control" />
                             <span asp-validation-for="DataHoraInicio" class="text-danger"></span>
                         </div>
                         <div class="form-group col-xxl-4">
                             <label asp-for="DataHoraFim" class="control-label"></label>
-                            <input asp-for="DataHoraFim" class="form-control" />
+                            <input asp-for="DataHoraFim" max="9999-12-31T23:59" class="form-control" />
                             <span asp-validation-for="DataHoraFim" class="text-danger"></span>
                         </div>
                     </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
@@ -25,12 +25,12 @@
                 <div class="row">
                     <div class="form-group col-xxl-4">
                         <label asp-for="DataHoraInicio" class="control-label"></label>
-                        <input asp-for="DataHoraInicio" class="form-control" />
+                        <input asp-for="DataHoraInicio" max="9999-12-31T23:59" class="form-control" />
                         <span asp-validation-for="DataHoraInicio" class="text-danger"></span>
                     </div>
                     <div class="form-group col-xxl-4">
                         <label asp-for="DataHoraFim" class="control-label"></label>
-                        <input asp-for="DataHoraFim" class="form-control" />
+                        <input asp-for="DataHoraFim" max="9999-12-31T23:59" class="form-control" />
                         <span asp-validation-for="DataHoraFim" class="text-danger"></span>
                     </div>
                 </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/Create.cshtml
@@ -30,7 +30,7 @@
                         </div>
                         <div class="form-group col-xl-4">
                             <label asp-for="Data" class="control-label"></label>
-                            <input asp-for="Data" class="form-control" />
+                            <input asp-for="Data" type="date" max="9999-12-31" class="form-control" />
                             <span asp-validation-for="Data" class="text-danger"></span>
                         </div>
                     </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Figurino/Edit.cshtml
@@ -30,7 +30,7 @@
                         </div>
                         <div class="form-group col-xl-4">
                             <label asp-for="Data" class="control-label"></label>
-                            <input asp-for="Data" class="form-control" />
+                            <input asp-for="Data" type="date" max="9999-12-31" class="form-control" />
                             <span asp-validation-for="Data" class="text-danger"></span>
                         </div>
                     </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Financeiro/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Financeiro/Edit.cshtml
@@ -33,13 +33,13 @@
             <div class="row">
                 <div class="form-group col-md-4 mb-3">
                     <label asp-for="DataInicio" class="control-label"></label>
-                    <input asp-for="DataInicio" type="date" class="form-control" value="@Model.DataInicio?.ToString("yyyy-MM-dd")" />
+                    <input asp-for="DataInicio" type="date" max="9999-12-31" class="form-control" value="@Model.DataInicio?.ToString("yyyy-MM-dd")" />
                     <span asp-validation-for="DataInicio" class="text-danger"></span>
                 </div>
 
                 <div class="form-group col-md-4 mb-3">
                     <label asp-for="DataFim" class="control-label"></label>
-                    <input asp-for="DataFim" type="date" class="form-control" value="@Model.DataFim?.ToString("yyyy-MM-dd")" />
+                    <input asp-for="DataFim" type="date" max="9999-12-31" class="form-control" value="@Model.DataFim?.ToString("yyyy-MM-dd")" />
                     <span asp-validation-for="DataFim" class="text-danger"></span>
                 </div>
 

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Create.cshtml
@@ -33,7 +33,7 @@
                         </div>
                         <div class="form-group  col-md-6">
                             <label asp-for="DataAquisicao" class="control-label"></label>
-                            <input asp-for="DataAquisicao" class="form-control" type="date"/>
+                            <input asp-for="DataAquisicao" max="9999-12-31" class="form-control" type="date" />
                             <span asp-validation-for="DataAquisicao" class="text-danger"></span>
 
                         </div>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/InstrumentoMusical/Edit.cshtml
@@ -33,7 +33,7 @@
                         </div>
                         <div class="form-group  col-md-6">
                             <label asp-for="DataAquisicao" class="control-label"></label>
-                            <input asp-for="DataAquisicao" class="form-control" type="date"/>
+                            <input asp-for="DataAquisicao" max="9999-12-31" class="form-control" type="date" />
                             <span asp-validation-for="DataAquisicao" class="text-danger"></span>
 
                         </div>


### PR DESCRIPTION


<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Descrição atual: O campo de data aceita formatos incorretos ou número excessivo de caracteres.

Comportamento Esperado: Ao digitar o ano no campo Data, o sistema deve limitar a entrada a apenas 4 dígitos.

seções:

-Ensaio
-Evento
-Instrumento
-Figurino

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [ ] Item 1
- [ ] Item 2 
- [x] Item 5

## Mudanças Que Não Estavam Previstas
seção Financeiro/ edit > campa data corrigido, permitindo apenas 4 dígitos.
- [x] Item 1
- [ ] Item 2 
- [ ] Item 3

## Como Testar
Acessar as seções e preencher campo data (Create / Edit).

## Prints
<img width="1849" height="815" alt="image" src="https://github.com/user-attachments/assets/9c3a436b-2dd5-40a0-a998-20845155e32b" />



