### PR TITLE
fix(evento): corrige participação e cancelamento de associados , erro de FK e alinhamento de botões  Refatoração da lógica de persistência para evitar truncamento de dados e correção do layout da página de detalhes do evento para o associado.

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -444,7 +444,16 @@ namespace GestaoGrupoMusicalWeb.Controllers
         [ValidateAntiForgeryToken]
         public async Task<ActionResult> CancelarSolicitacao(int idEvento)
         {
-            int idPessoa = Convert.ToInt32(User.FindFirst("Id")?.Value);
+
+            var claimId = User.FindFirst("Id")?.Value;
+
+            if (string.IsNullOrEmpty(claimId))
+            {
+                Notificar("Erro: Identificador numérico não encontrado no perfil.", Notifica.Erro);
+                return RedirectToAction("Index","Home");
+            }
+          
+            int idPessoa = Convert.ToInt32(claimId);
 
             var resultado = await _eventoService.CancelarSolicitacao(idEvento, idPessoa);
 

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/EnsaiosAssociado.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/EnsaiosAssociado.cshtml
@@ -147,13 +147,14 @@
                                             <i class="fa-solid fa-circle-check me-1"></i>
                                             Realizada
                                         </div>
-                                      <td>
-                                          <a class="btn btn-secondary btn-sm" role="button" asp-controller="Evento" asp-action="SolicitarParticipacao" asp-route-id="@item.Id">
-                                                <i class="fa-solid fa-circle-info"></i>
-                                                Detalhes   
-                                          </a>
-                                    </td>
                                     }
+                                </td>
+
+                                <td>
+                                    <a class="btn btn-secondary btn-sm" role="button" asp-controller="Evento" asp-action="SolicitarParticipacao" asp-route-id="@item.Id">
+                                        <i class="fa-solid fa-circle-info"></i>
+                                        Detalhes
+                                    </a>
                                 </td>
                             </tr>
                         }

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/SolicitarParticipacao.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/SolicitarParticipacao.cshtml
@@ -38,9 +38,9 @@
     @* SEÇÃO 1: Se o usuário já estiver inscrito *@
     @if (Model.MinhaInscricao != null && Model.MinhaInscricao.StatusEnum != InscricaoEventoPessoa.NAO_SOLICITADO)
     {
-        <div class="alert alert-info">
+        <div class="alert alert-info shadow-sm">
             <h4 class="alert-heading">Sua Situação</h4>
-            <p>
+            <p class="mb-0">
                 <strong>Status:</strong> @Model.MinhaInscricao.Status<br />
                 @if (!string.IsNullOrEmpty(Model.MinhaInscricao.NomeInstrumento))
                 {
@@ -50,45 +50,54 @@
             </p>
         </div>
 
-        @if (Model.PodeCancelar)
-        {
-            <form asp-action="CancelarSolicitacao" method="post">
-                <input type="hidden" name="idEvento" value="@Model.Id" />
-                <button type="submit" class="btn btn-warning">Cancelar Solicitação</button>
-            </form>
-        }
+        <div class="d-flex justify-content-end gap-2 mt-4">
+            <a asp-controller="Ensaio" asp-action="EnsaiosAssociado" class="btn btn-secondary col-1">Voltar</a>
+            @if (Model.PodeCancelar)
+            {
+                <form asp-action="CancelarSolicitacao" method="post">
+                    <input type="hidden" name="idEvento" value="@Model.Id" />
+                    <button type="submit" class="btn btn-outline-secondary">Cancelar Solicitação</button>
+                </form>
+            }
+        </div>
     }
     @* SEÇÃO 2: Se o usuário ainda pode se inscrever *@
     else if (Model.PodeInscrever)
     {
-        <h3>Escolha seu instrumento</h3>
-        <form asp-action="ConfirmarSolicitacao" method="post">
-            <input type="hidden" name="IdEvento" value="@Model.Id" />
+        <div class="card border-light shadow-sm">
+            <div class="card-body">
+                <h3 class="fs-5 mb-3">Escolha seu instrumento</h3>
+                <form asp-action="ConfirmarSolicitacao" method="post">
+                    <input type="hidden" name="IdEvento" value="@Model.Id" />
 
-            <div class="form-group mb-3">
-                <label for="IdTipoInstrumento" class="form-label">Instrumentos com vagas:</label>
-                <select name="IdTipoInstrumento" class="form-select" required>
-                    <option value="">Selecione um instrumento...</option>
-                    @foreach (var instrumento in Model.InstrumentosDisponiveis.Where(i => i.VagasDisponiveis > 0))
-                    {
-                        <option value="@instrumento.IdInstrumento">
-                            @instrumento.NomeInstrumento (@instrumento.VagasDisponiveis vagas)
-                        </option>
-                    }
-                </select>
+                    <div class="form-group mb-4">
+                        <label for="IdTipoInstrumento" class="form-label">Instrumentos com vagas:</label>
+                        <select name="IdTipoInstrumento" class="form-select" required>
+                            <option value="">Selecione um instrumento...</option>
+                            @foreach (var instrumento in Model.InstrumentosDisponiveis.Where(i => i.VagasDisponiveis > 0))
+                            {
+                                <option value="@instrumento.IdInstrumento">
+                                    @instrumento.NomeInstrumento (@instrumento.VagasDisponiveis vagas)
+                                </option>
+                            }
+                        </select>
+                    </div>
+
+                    <div class="d-flex justify-content-end gap-2">
+                        <a asp-controller="Ensaio" asp-action="EnsaiosAssociado" class="btn btn-secondary col-1">Voltar</a>
+                        <button type="submit" class="btn btn-outline-secondary">Confirmar Inscrição</button>
+                    </div>
+                </form>
             </div>
-
-            <button type="submit" class="btn btn-success">Confirmar Inscrição</button>
-        </form>
+        </div>
     }
     else
     {
-        <div class="alert alert-warning">
+        <div class="alert alert-warning shadow-sm">
             Não é mais possível se inscrever ou alterar sua inscrição para este evento.
         </div>
+        <div class="d-flex justify-content-end">
+            <a asp-controller="Ensaio" asp-action="EnsaiosAssociado" class="btn btn-secondary col-2">Voltar</a>
+        </div>
     }
-
-    <div class="mt-4">
-        <a asp-controller="Ensaio" asp-action="EnsaiosAssociado" class="btn btn-secondary">Voltar</a>
-    </div>
 </div>


### PR DESCRIPTION
Close #806<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
[Descreva aqui o que foi solicitado e o objetivo deste Pull Request.]

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x]  corrige participação em eventos.
- [x]  corrige cancelamento de participação em eventos.
- [x]  Refatoração da lógica de persistência para evitar erros de truncamento de dados (ENUM).
- [x] Correção de erro de Chave Estrangeira (FK) ao tratar IDs de instrumentos.
- [x] Ajuste do layout na página de detalhes, alinhando botões de ação à direita com espaçamento padronizado.
- [x] Alteração da lógica de cancelamento para remoção de registro, permitindo que o estado 'NAO_SOLICITADO' seja reativado na View.


## Mudanças Que Não Estavam Previstas

- [x] varias
- [ ] Item 2 
- [ ] Item 3

## Como Testar
Conta Associado > Sessão eventos e Ensaios > (Eventos cadastrados)

Clicar no botão (Quero participar).

Comportamento Esperado: O sistema deve confirmar a presença do associado.

## Prints
<img width="1292" height="514" alt="image" src="https://github.com/user-attachments/assets/11cc5a9c-4fdb-4c6e-9e4b-194d7b65f63d" />
<img width="1302" height="630" alt="image" src="https://github.com/user-attachments/assets/f2a7f1ff-488c-41f1-aaa3-a96ad40823d7" />




**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
