### PR TITLE
feat: adicionar suporte a autenticação JWT no Swagger.

### DIFF
--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/FinanceiroController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/FinanceiroController.cs
@@ -3,13 +3,14 @@ using Core.Service;
 using Core.DTO;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 
 
 namespace GestaoGrupoMusicalAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    //[Authorize]
+    [Authorize(Roles = "REGENTE")]
     public class FinanceiroController : ControllerBase
     {
         private readonly IFinanceiroService financeiroService;

--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/IdentityController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/IdentityController.cs
@@ -1,6 +1,7 @@
 ﻿using Core;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
@@ -12,29 +13,32 @@ namespace GestaoGrupoMusicalAPI.Controllers
     [ApiController]
     public class IdentityController : ControllerBase
     {
-        private readonly SignInManager<UsuarioIdentity> _signInManager;
-        private readonly UserManager<UsuarioIdentity> _userManager;
-        private readonly IConfiguration _configuration;
+        private readonly SignInManager<UsuarioIdentity> signInManager;
+        private readonly UserManager<UsuarioIdentity> userManager;
+        private readonly IConfiguration configuration;
+        private readonly GrupoMusicalContext context;
 
         public IdentityController(
             SignInManager<UsuarioIdentity> signInManager,
             UserManager<UsuarioIdentity> userManager,
+            GrupoMusicalContext context, 
             IConfiguration configuration)
         {
-            _signInManager = signInManager;
-            _userManager = userManager;
-            _configuration = configuration;
+            this.signInManager = signInManager;
+            this.userManager = userManager;
+            this.configuration = configuration;
+            this.context = context; 
         }
 
         [HttpPost("login")]
         public async Task<IActionResult> Login([FromBody] LoginModel model)
         {
             // O web usa CPF como nome de usuário
-            var result = await _signInManager.PasswordSignInAsync(model.Cpf ?? "", model.Senha ?? "", false, false);
+            var result = await signInManager.PasswordSignInAsync(model.Cpf ?? "", model.Senha ?? "", false, false);
 
             if (result.Succeeded)
             {
-                var user = await _userManager.FindByNameAsync(model.Cpf ?? "");
+                var user = await userManager.FindByNameAsync(model.Cpf ?? "");
                 if (user == null) return Unauthorized();
 
                 var token = await GerarTokenJwt(user);
@@ -47,16 +51,24 @@ namespace GestaoGrupoMusicalAPI.Controllers
         private async Task<string> GerarTokenJwt(UsuarioIdentity user)
         {
             var tokenHandler = new JwtSecurityTokenHandler();
-            var secret = _configuration["Jwt:ChaveSecreta"] ?? "CHAVE_PADRAO_COM_MAIS_DE_32_CARACTERES";
+            var secret = configuration["Jwt:ChaveSecreta"] ?? "CHAVE_PADRAO_COM_MAIS_DE_32_CARACTERES";
             var key = Encoding.ASCII.GetBytes(secret);
 
-            var roles = await _userManager.GetRolesAsync(user);
+            var roles = await userManager.GetRolesAsync(user);
+
+            var pessoaLogada = context.Pessoas.FirstOrDefault(p => p.Cpf == user.UserName);
+
             var claims = new List<Claim>
             {
                 new Claim(ClaimTypes.Name, user.UserName ?? ""),
-                new Claim(ClaimTypes.Email, user.Email ?? ""),
-                new Claim("Id", user.Id)
+                new Claim("Id", user.Id),
             };
+
+            if (pessoaLogada != null)
+            {
+                claims.Add(new Claim("IdGrupoMusical", pessoaLogada.IdGrupoMusical.ToString()));
+                claims.Add(new Claim("IdPessoa", pessoaLogada.Id.ToString()));
+            }
 
             foreach (var role in roles)
             {
@@ -68,8 +80,8 @@ namespace GestaoGrupoMusicalAPI.Controllers
                 Subject = new ClaimsIdentity(claims),
                 Expires = DateTime.UtcNow.AddHours(2),
                 SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature),
-                Issuer = _configuration["Jwt:Emissor"],
-                Audience = _configuration["Jwt:Audiencia"]
+                Issuer = configuration["Jwt:Emissor"],
+                Audience = configuration["Jwt:Audiencia"]
             };
 
             var token = tokenHandler.CreateToken(tokenDescriptor);

--- a/Codigo/GestaoGrupoMusicalAPI/Program.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Program.cs
@@ -53,7 +53,39 @@ builder.Services.AddAuthentication(x =>
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+    {
+        Title = "Gestão Grupo Musical API",
+        Version = "v1"
+    });
+
+    // Isso cria o botão "Authorize" (Cadeado) no Swagger
+    c.AddSecurityDefinition("Bearer", new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+    {
+        Description = "JWT Authorization header. Digite: 'Bearer {seu_token}'",
+        Name = "Authorization",
+        In = Microsoft.OpenApi.Models.ParameterLocation.Header,
+        Type = Microsoft.OpenApi.Models.SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+
+    c.AddSecurityRequirement(new Microsoft.OpenApi.Models.OpenApiSecurityRequirement
+    {
+        {
+            new Microsoft.OpenApi.Models.OpenApiSecurityScheme
+            {
+                Reference = new Microsoft.OpenApi.Models.OpenApiReference
+                {
+                    Type = Microsoft.OpenApi.Models.ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            new string[] {}
+        }
+    });
+});
 
 builder.Services.AddTransient<IPessoaService, PessoaService>();
 builder.Services.AddAutoMapper(AppDomain.CurrentDomain.GetAssemblies());


### PR DESCRIPTION
Close #836

<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Atualmente, a API utiliza autenticação baseada em JWT, mas o Swagger não está configurado para permitir o envio do token no cabeçalho Authorization. Isso impede o teste de endpoints protegidos pelo atributo [Authorize] diretamente pela interface do Swagger.

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x] Configurar AddSecurityDefinition no AddSwaggerGen para registrar o esquema Bearer.
- [x] Configurar AddSecurityRequirement para exigir o token globalmente ou em rotas específicas no Swagger UI.
- [x] Validar o envio do cabeçalho Authorization: Bearer {token} nas requisições.

## Mudanças Que Não Estavam Previstas
[Caso tenha feito alguma alteração extra que não estava originalmente planejada, descreva-as aqui. Use o checklist markdown como o exemplo abaixo]
- [x] Incluido a propriedade Roles ([Authorize(Roles = "REGENTE")]) no Financeiro.
- [ ] Item 2 
- [ ] Item 3

## Como Testar
GestaoGrupoMusicalAPI> Identity
- acesse uma conta
- pegue o hash gerado ex: 'eyJ....'
- clique em Autorize e adicione "Bearer" +  1 espaço + hash.
- clique em Close
- Teste o get do Financeiro e do Informativo; 

## Prints
<img width="695" height="354" alt="image" src="https://github.com/user-attachments/assets/5ae72b07-5696-494c-8a6a-5ef24f845efc" />
<img width="1158" height="643" alt="image" src="https://github.com/user-attachments/assets/c7d08e80-81a7-47de-977b-d54ecba52a9c" />

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
