### PR TITLE
fix: resolve issue #875 corrigindo palavra 'geremciamento'

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -531,7 +531,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                     Notificar("<b>Erro!</b> Ultrapassou o <b>limite</b> de participação de associados em um determinado <b>instrumento</b>", Notifica.Erro);
                     break;
                 default:
-                    Notificar("Desculpe, ocorreu um <b>Erro</b> durante o geremciamento de <b>solicitação</b> dos associados.", Notifica.Erro);
+                    Notificar("Desculpe, ocorreu um <b>Erro</b> durante o gerenciamento de <b>solicitação</b> dos associados.", Notifica.Erro);
                     break;
             }
             


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Correção de erro gramatical na palavra 'geremciamento'.

## Foi Feito
Dentro da controller `Evento.cs`, foi corrigida a palavra 'geremciamento' para 'gerenciamento'.

## Mudanças Que Não Estavam Previstas
Não consta.

## Como Testar
Executa o código 
Autenticação como administrador
Vai até seção de eventos
solicitações de um evento
Muda o "status" de algum candidato para "inscrito"
Salva
Irá mostrar a palavra gerenciamento escrita corretamente

## Prints
![WhatsApp Image 2026-04-09 at 15 01 55](https://github.com/user-attachments/assets/c41c7e26-6389-4ed5-aeff-76a8f741ac25)


**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
