### PR TITLE
fix(web): valor padrão para Data de Aquisição em Instrumentos corrigido

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Models/InstrumentoMusicalViewModel.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Models/InstrumentoMusicalViewModel.cs
@@ -15,9 +15,9 @@ namespace GestaoGrupoMusicalWeb.Models
         [StringLength(20, MinimumLength = 5, ErrorMessage = "O nome do associado deve ter entre 5 e 20 caracteres")]
         public string Patrimonio { get; set; }
 
-        [Display(Name ="Data Aquisição")]
-        [Required(ErrorMessage ="A data é obrigatória")]
-        public DateTime DataAquisicao { get; set; }
+        [Display(Name = "Data Aquisição")]
+        [Required(ErrorMessage = "A data é obrigatória")]
+        public DateTime DataAquisicao { get; set; } = DateTime.Today;
 
         [Required(ErrorMessage = "O campo {0} é obrigatório")]
         [Display(Name = "Status")]


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Correção de valor nulo para Data de Aquisição de Instrumentos 

## Foi Feito
- [x] Correção para valor atual da Data de Aquisição da seção de Novos Instrumentos 

## Mudanças Que Não Estavam Previstas
Não se aplica

## Como Testar
1. Autenticação como administrador (Web)
2. Seção de Instrumentos Musicais
3. Novo Instrumento

## Prints
<img width="544" height="399" alt="Captura de tela de 2026-04-24 13-21-11" src="https://github.com/user-attachments/assets/678d9ee9-f8b3-4c47-a1c0-536eec638809" />


**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
