### PR TITLE
feat: Adicionar validação e alerta para associados sem instrumento em eventos

### DIFF
--- a/Codigo/Core/Service/IEventoService.cs
+++ b/Codigo/Core/Service/IEventoService.cs
@@ -49,7 +49,8 @@ namespace Core.Service
             ErroGenerico,
             SemAlteracao,
             QuantidadeConfirmadaNegativa,
-            QuantidadeSolicitadaNegativa
+            QuantidadeSolicitadaNegativa,
+            AssociadoSemInstrumento
         }
         IEnumerable<InstrumentoSolicitacaoDTO> GetInstrumentosDisponiveis(int idEvento);
         Task<HttpStatusCode> SolicitarParticipacao(int idEvento, int idPessoa, int idTipoInstrumento);

--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -530,6 +530,9 @@ namespace GestaoGrupoMusicalWeb.Controllers
                 case IEventoService.EventoStatus.UltrapassouLimiteQuantidadePlanejada:
                     Notificar("<b>Erro!</b> Ultrapassou o <b>limite</b> de participação de associados em um determinado <b>instrumento</b>", Notifica.Erro);
                     break;
+                case IEventoService.EventoStatus.AssociadoSemInstrumento:
+                    Notificar("<b>Alerta!</b> Não houve alterações na solicitação de participação do evento, <b>associados sem Instumentos</b>.", Notifica.Informativo);
+                    break;
                 default:
                     Notificar("Desculpe, ocorreu um <b>Erro</b> durante o gerenciamento de <b>solicitação</b> dos associados.", Notifica.Erro);
                     break;

--- a/Codigo/Service/EventoService.cs
+++ b/Codigo/Service/EventoService.cs
@@ -10,6 +10,7 @@ using System.Net;
 using System.Numerics;
 using System.Runtime.ConstrainedExecution;
 using System.Runtime.Intrinsics.X86;
+using System.Transactions;
 using static Core.Service.IEventoService;
 
 
@@ -832,11 +833,17 @@ namespace Service
                 {
                     for (int i = 0; i < auxSolicitacaoEvento.Count; i++)
                     {
+
+                        if (auxSolicitacaoEvento[i].IdInstrumento == 0) 
+                        {
+                            transaction.Rollback();
+                            return EventoStatus.AssociadoSemInstrumento;
+                        }
                         Eventopessoa? e = _context.Eventopessoas.Where(
                             ep => ep.IdPessoa == auxSolicitacaoEvento[i].IdAssociado &&
                             ep.IdTipoInstrumento == auxSolicitacaoEvento[i].IdInstrumento &&
                             ep.IdEvento == g.Id
-                        ).FirstOrDefault();
+                        ).FirstOrDefault();                    
                         if (e != null)
                         {
                             e.Status = auxSolicitacaoEvento[i].AprovadoModel.ToString();
@@ -864,6 +871,12 @@ namespace Service
                     {
                         for (int i = 0; i < auxSolicitacaoEvento.Count; i++)
                         {
+                            if (auxSolicitacaoEvento[i].IdInstrumento == 0)
+                            {
+                                transaction.Rollback();
+                                return EventoStatus.AssociadoSemInstrumento;
+                            }
+
                             Eventopessoa? e = _context.Eventopessoas.Where(
                             ep => ep.IdPessoa == auxSolicitacaoEvento[i].IdAssociado &&
                             ep.IdTipoInstrumento == auxSolicitacaoEvento[i].IdInstrumento &&
@@ -876,6 +889,7 @@ namespace Service
                                 if (auxSolicitacaoEvento[i].Aprovado == InscricaoEventoPessoa.DEFERIDO)
                                 {
                                     auxAt.QuantidadeConfirmada--;
+                                    
                                 }
                                 else if (auxSolicitacaoEvento[i].Aprovado == InscricaoEventoPessoa.INDEFERIDO || auxSolicitacaoEvento[i].Aprovado == InscricaoEventoPessoa.INSCRITO)
                                 {
@@ -886,6 +900,7 @@ namespace Service
                                     transaction.Rollback();
                                     return EventoStatus.ErroGenerico;
                                 }
+                                
                                 if (auxAt.QuantidadeConfirmada < 0)
                                 {
                                     transaction.Rollback();


### PR DESCRIPTION
#876



<div align="center">

  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">

  <h1>Pull Request</h1> 

</div>

## Foi Solicitado
Corrigir a falha no gerenciamento de aprovações de participação em eventos para associados que não possuem instrumento vinculado.

Existe uma regra de negócio fundamental no sistema que exige que, para um associado ser aprovado/inscrito em um evento, ele obrigatoriamente precisa estar com um instrumento. Antes dessa alteração, quando o IdInstrumento vinha zerado (associado sem instrumento), o sistema tentava fazer buscas inválidas no banco de dados, resultando em uma falha na transação e exibindo um erro genérico na tela do usuário, sem explicar o real motivo do bloqueio.

## Foi Feito
[x] Criação do novo status de retorno AssociadoSemInstrumento no enum EventoStatus (IEventoService.cs).

[x] Inclusão de uma validação de bloqueio imediato (early return com Rollback) na EventoService.cs nos laços de aprovação. Se o DTO receber IdInstrumento == 0, a operação é cancelada e o status correto é retornado.

[x] Adição do tratamento no switch-case da EventoController.cs para capturar esse novo status e exibir um alerta informativo, orientando o administrador de forma clara.

## Mudanças Que Não Estavam Previstas
[x] Aplicação da validação do instrumento nos dois laços de repetição dentro do EditSolicitacoesEvento (tanto no bloco que processa status Inscrito/Indeferido, quanto no bloco que processa o Deferido), garantindo que nenhuma brecha permita furar a regra de negócio.

## Como Testar
Acesse o sistema e navegue até a tela de gerenciamento de solicitações de um Evento.

Identifique ou simule a solicitação de um associado que não possui instrumento vinculado ao seu cadastro.

Tente alterar o status desse associado para Deferido ou Inscrito e salve.

O sistema deve bloquear a inscrição e exibir a seguinte notificação amarela: "Alerta! Não houve alterações na solicitação de participação do evento, associados sem Instrumentos."

Repita o processo com um associado com instrumento para garantir que o fluxo de aprovação normal continua funcionando perfeitamente.

## Prints
<img width="1640" height="871" alt="image" src="https://github.com/user-attachments/assets/bfedfb71-ccad-4c79-8c87-141d19190cff" />


Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.