### PR TITLE
fix: ajuste de layout no espaçamento de seção de eventos e ensaios mo…

### DIFF
--- a/Codigo/GestaoGrupoMusicalMobile/lib/screens/home_view.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/screens/home_view.dart
@@ -29,7 +29,7 @@ class HomeView extends StatelessWidget {
             ensaioService.getAll(), 
             (item) => _buildEnsaioCard(item)
           ),
-          const SizedBox(height: 100),
+          const SizedBox(height: 60),
         ],
       ),
     );
@@ -40,38 +40,42 @@ class HomeView extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start, 
       children: [
         Padding(
-          padding: const EdgeInsets.fromLTRB(16, 20, 16, 8), 
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 4), 
           child: Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold))
         ),
-        SizedBox(
-          height: 185, 
-          child: FutureBuilder<List<T>>(
-            future: future,
-            builder: (context, snapshot) {
-              if (snapshot.connectionState == ConnectionState.waiting) {
-                return const Center(child: CircularProgressIndicator());
-              }
-              if (snapshot.hasError) {
-                return Center(child: Text("Erro ao carregar $title"));
-              }
-              final list = snapshot.data ?? [];
-              if (list.isEmpty) {
-                return const Padding(
-                  padding: EdgeInsets.only(left: 16.0),
-                  child: Text("Nada agendado por enquanto."),
-                );
-              }
-              return ListView.builder(
-                scrollDirection: Axis.horizontal, 
-                // 🔥 Efeito de "mola" nativo ao deslizar (deixa o toque muito mais suave)
-                physics: const BouncingScrollPhysics(), 
-                // 🔥 Dá um espaço de respiro no final para o último card não grudar na borda
-                padding: const EdgeInsets.only(right: 16), 
-                itemCount: list.length, 
-                itemBuilder: (context, i) => builder(list[i])
+        FutureBuilder<List<T>>(
+          future: future,
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Padding(
+                padding: EdgeInsets.only(left: 16.0),
+                child: SizedBox(height: 30, child: CircularProgressIndicator()),
               );
-            },
-          ),
+            }
+            if (snapshot.hasError) {
+              return Padding(
+                padding: const EdgeInsets.only(left: 16.0),
+                child: Text("Erro ao carregar $title"),
+              );
+            }
+            final list = snapshot.data ?? [];
+            if (list.isEmpty) {
+              return const Padding(
+                padding: EdgeInsets.only(left: 16.0),
+                child: Text("Nada agendado por enquanto."),
+              );
+            }
+            return SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              physics: const BouncingScrollPhysics(),
+              child: Padding(
+                padding: const EdgeInsets.only(right: 16),
+                child: Row(
+                  children: List.generate(list.length, (i) => builder(list[i])),
+                ),
+              ),
+            );
+          },
         )
       ]
     );
@@ -103,14 +107,15 @@ class HomeView extends StatelessWidget {
     Widget? actionWidget,
   }) {
     return Container(
-      width: 270,
-      margin: const EdgeInsets.only(left: 16, bottom: 5),
+      width: 232,
+      margin: const EdgeInsets.only(left: 16, bottom: 2),
       child: Card(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
         elevation: 4,
         child: Padding(
-          padding: const EdgeInsets.all(14.0),
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
           child: Column(
+            mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
@@ -118,20 +123,22 @@ class HomeView extends StatelessWidget {
                 children: [
                   Expanded(
                     child: Text(title, 
-                      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16), 
+                      style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 14), 
                       maxLines: 1, overflow: TextOverflow.ellipsis
                     ),
                   ),
                   if (trailing != null) trailing,
                 ],
               ),
-              const SizedBox(height: 8),
+              const SizedBox(height: 1),
               Text(
                 "📅 ${date.day.toString().padLeft(2, '0')}/${date.month.toString().padLeft(2, '0')} às ${date.hour}:${date.minute.toString().padLeft(2, '0')}",
-                style: TextStyle(color: Colors.grey[700], fontSize: 13),
+                style: TextStyle(color: Colors.grey[700], fontSize: 11),
               ),
-              const Spacer(),
-              if (actionWidget != null) actionWidget, 
+              if (actionWidget != null) ...[
+                const SizedBox(height: 2),
+                actionWidget,
+              ],
             ],
           ),
         ),
@@ -319,7 +326,7 @@ class _EventToggleButtonState extends State<EventToggleButton> {
         backgroundColor: _isAccepted ? Colors.grey[200] : AppColors.primary,
         foregroundColor: _isAccepted ? Colors.black87 : Colors.white,
         elevation: _isAccepted ? 0 : 2,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
       ),
       child: _isLoading 


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Reduzir o espaçamento visual (padding/margin) na seção de Eventos e Ensaios da tela Home para melhor aproveitamento de tela, deixando os cards com tamanho dinâmico que se adapta ao conteúdo (nome e data do evento/ensaio).

**Objetivo:** 
- Aproveitar melhor o espaço disponível na tela
- Tornar o layout responsivo ao crescimento de eventos/ensaios
- Manter a legibilidade e usabilidade da interface

## Foi Feito

- [x] O novo layout usa `SingleChildScrollView` com `Row` em vez de `ListView.builder` para permitir que a altura seja controlada pelo conteúdo
- [x]  `mainAxisSize: MainAxisSize.min` garante que os widgets ocupem apenas o espaço necessário
- [x]   BouncingScrollPhysics()` mantém o efeito suave de scroll nativo do Flutter
- [x] A quebra de conteúdo (ellipsis) ainda está ativa em `maxLines: 1` para títulos muito longos 

## Mudanças Que Não Estavam Previstas

- [x] Ajuste da estrutura de rendering para suportar tamanho dinâmico do container
- [x] Otimização do espaçamento entre margens dos cards (de `bottom: 5` para `bottom: 2`)
- [x] Redução do espaço final da página (SizedBox) de `100` para `60` para melhor fluxo visual


## Arquivos Modificados

- `lib/screens/home_view.dart` - Refatoração da seção de listagem e compactação dos cards



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
