### PR TITLE
feat: paginação e ordenação de avisos com foco em economia de dados.

### DIFF
--- a/Codigo/GestaoGrupoMusicalMobile/lib/screens/informativo_view.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/screens/informativo_view.dart
@@ -2,44 +2,254 @@ import 'package:batala_mobile/model/informativo_model.dart';
 import 'package:batala_mobile/service/informativo_service.dart';
 import 'package:flutter/material.dart';
 
-class InformativoView extends StatelessWidget {
+class InformativoView extends StatefulWidget {
   const InformativoView({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    final service = InformativoService();
+  State<InformativoView> createState() => _InformativoViewState();
+}
 
-    // Retornamos apenas o FutureBuilder, sem Scaffold ou AppBar
-    return FutureBuilder<List<InformativoModel>>(
-      future: service.getAll(),
-      builder: (context, snapshot) {
-        if (snapshot.connectionState == ConnectionState.waiting) {
-          return const Center(child: CircularProgressIndicator());
-        } else if (snapshot.hasError) {
-          return Center(child: Text("Erro: ${snapshot.error}"));
-        } else if (snapshot.hasData) {
-          final informativos = snapshot.data!;
-          return ListView.builder(
-            // Adicionamos um padding para o conteúdo não colar no topo
-            padding: const EdgeInsets.only(top: 10, bottom: 100), 
-            itemCount: informativos.length,
-            itemBuilder: (context, index) => ListTile(
-              leading: const Icon(Icons.info_outline, color: Color(0xFFD64550)),
-              title: Text(
-                informativos[index].mensagem,
-                style: const TextStyle(fontWeight: FontWeight.bold),
+class _InformativoViewState extends State<InformativoView> {
+  late InformativoService service;
+  final ScrollController _scrollController = ScrollController();
+  
+  int _currentPage = 1;
+  final int _pageSize = 10;
+  List<InformativoModel> _allItems = [];
+  bool _isLoadingMore = false;
+  bool _hasMorePages = true;
+  bool _isInitialLoading = true;
+  bool _isFromCache = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    service = InformativoService();
+    _loadFirstPage();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadFirstPage() async {
+    setState(() {
+      _isInitialLoading = true;
+      _errorMessage = null;
+      _allItems = [];
+      _currentPage = 1;
+      _hasMorePages = true;
+    });
+
+    try {
+      final result = await service.getPaginated(
+        pageNumber: 1,
+        pageSize: _pageSize,
+      );
+
+      setState(() {
+        _allItems = result.items;
+        _hasMorePages = result.hasMorePages;
+        _isFromCache = result.isFromCache;
+        _isInitialLoading = false;
+      });
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Erro ao carregar avisos: $e';
+        _isInitialLoading = false;
+      });
+      debugPrint('Erro ao carregar primeira página: $e');
+    }
+  }
+
+  Future<void> _loadMorePages() async {
+    if (_isLoadingMore || !_hasMorePages) return;
+
+    setState(() {
+      _isLoadingMore = true;
+    });
+
+    try {
+      final nextPage = _currentPage + 1;
+      final result = await service.getPaginated(
+        pageNumber: nextPage,
+        pageSize: _pageSize,
+      );
+
+      setState(() {
+        _allItems.addAll(result.items);
+        _hasMorePages = result.hasMorePages;
+        _currentPage = nextPage;
+        _isLoadingMore = false;
+      });
+    } catch (e) {
+      setState(() {
+        _isLoadingMore = false;
+      });
+      debugPrint('Erro ao carregar página ${_currentPage + 1}: $e');
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Erro ao carregar mais avisos: $e'),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      }
+    }
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+            _scrollController.position.maxScrollExtent * 0.8 &&
+        !_isLoadingMore &&
+        _hasMorePages) {
+      _loadMorePages();
+    }
+  }
+
+  Future<void> _refreshData() async {
+    await service.refreshCache();
+    await _loadFirstPage();
+  }
+
+  Widget _buildCacheBadge() {
+    if (_isFromCache) {
+      return Container(
+        margin: const EdgeInsets.only(top: 8, left: 16, right: 16),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: Colors.blue.shade100,
+          borderRadius: BorderRadius.circular(20),
+          border: Border.all(color: Colors.blue.shade300),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.storage, size: 14, color: Colors.blue.shade700),
+            const SizedBox(width: 6),
+            Text(
+              'Carregado do cache (dados locais)',
+              style: TextStyle(
+                fontSize: 12,
+                color: Colors.blue.shade700,
               ),
-            subtitle: Text(
-              "Postado em: ${informativos[index].dataInicio.day.toString().padLeft
-              (2, '0')}/${informativos[index].dataInicio.month.toString().padLeft
-              (2, '0')}/${informativos[index].dataInicio.year} às ${informativos[index].dataInicio.hour.toString().padLeft
-              (2, '0')}:${informativos[index].dataInicio.minute.toString().padLeft(2, '0')}",
             ),
+          ],
+        ),
+      );
+    }
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isInitialLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_errorMessage != null) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Erro: $_errorMessage'),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _loadFirstPage,
+              child: const Text('Tentar Novamente'),
             ),
-          );
-        }
-        return const Center(child: Text("Nenhum informativo encontrado"));
-      },
+          ],
+        ),
+      );
+    }
+
+    if (_allItems.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.info_outline, size: 48, color: Colors.grey.shade400),
+            const SizedBox(height: 16),
+            Text(
+              'Nenhum aviso encontrado',
+              style: TextStyle(color: Colors.grey.shade600, fontSize: 16),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: _refreshData,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Atualizar'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: _refreshData,
+      child: ListView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.only(top: 10, bottom: 100),
+        itemCount: _allItems.length + (_hasMorePages ? 2 : 1),
+        itemBuilder: (context, index) {
+          // Mostrar badge de cache no início
+          if (index == 0 && _isFromCache) {
+            return Column(
+              children: [
+                _buildCacheBadge(),
+                const SizedBox(height: 8),
+                _buildInformativoTile(_allItems[index]),
+              ],
+            );
+          }
+
+          // Se estamos no índice que tem a badge, mostrar o item normalmente
+          int itemIndex = _isFromCache ? index - 1 : index;
+
+          if (itemIndex < _allItems.length) {
+            return _buildInformativoTile(_allItems[itemIndex]);
+          }
+
+          // Mostrar indicador de carregamento se há mais páginas
+          if (_hasMorePages && index == _allItems.length + (_isFromCache ? 1 : 0)) {
+            return Padding(
+              padding: const EdgeInsets.symmetric(vertical: 16),
+              child: _isLoadingMore
+                  ? const Center(child: CircularProgressIndicator())
+                  : Center(
+                      child: ElevatedButton.icon(
+                        onPressed: _loadMorePages,
+                        icon: const Icon(Icons.expand_more),
+                        label: const Text('Carregar Mais'),
+                      ),
+                    ),
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
+    );
+  }
+
+  Widget _buildInformativoTile(InformativoModel informativo) {
+    return ListTile(
+      leading: const Icon(Icons.info_outline, color: Color(0xFFD64550)),
+      title: Text(
+        informativo.mensagem,
+        style: const TextStyle(fontWeight: FontWeight.bold),
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        "Postado em: ${informativo.dataInicio.day.toString().padLeft(2, '0')}/${informativo.dataInicio.month.toString().padLeft(2, '0')}/${informativo.dataInicio.year} às ${informativo.dataInicio.hour.toString().padLeft(2, '0')}:${informativo.dataInicio.minute.toString().padLeft(2, '0')}",
+      ),
+      isThreeLine: true,
     );
   }
 }

--- a/Codigo/GestaoGrupoMusicalMobile/lib/service/informativo_service.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/service/informativo_service.dart
@@ -6,56 +6,146 @@ import '../config/cache_manager.dart';
 import '../config/session_manager.dart';
 import '../model/informativo_model.dart';
 
+class PaginatedInformativeResult {
+  final List<InformativoModel> items;
+  final int pageNumber;
+  final int pageSize;
+  final int totalItems;
+  final bool hasMorePages;
+  final bool isFromCache;
+
+  PaginatedInformativeResult({
+    required this.items,
+    required this.pageNumber,
+    required this.pageSize,
+    required this.totalItems,
+    required this.hasMorePages,
+    required this.isFromCache,
+  });
+}
+
 class InformativoService {
   static const String _cacheKey = 'informativo_list';
-  
+  static const int _defaultPageSize = 10;
+
+  /// Busca todos os informativos (sem paginação - para cache/sincronização)
   Future<List<InformativoModel>> getAll() async {
-  try {
-    // Tenta recuperar do cache primeiro
-    final cachedData = await CacheManager.getCache(_cacheKey);
-    if (cachedData != null) {
-      debugPrint('Usando dados em cache para informativos');
-      final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
-      return data.map((e) => InformativoModel.fromJson(e)).toList();
+    try {
+      // Tenta recuperar do cache primeiro
+      final cachedData = await CacheManager.getCache(_cacheKey);
+      if (cachedData != null) {
+        debugPrint('Usando dados em cache para informativos');
+        final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
+        return _ordenarPorDataDecrescente(
+          data.map((e) => InformativoModel.fromJson(e)).toList()
+        );
+      }
+    } catch (e) {
+      debugPrint('Erro ao recuperar cache de informativos: $e');
     }
-  } catch (e) {
-    debugPrint('Erro ao recuperar cache de informativos: $e');
+
+    try {
+      final String? token = await SessionManager.getToken();
+      final response = await http.get(
+        Uri.parse('${ApiConfig.baseUrl}/api/Informativo/Grupo'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        final List data = jsonDecode(response.body);
+        final informativos = data.map((e) => InformativoModel.fromJson(e)).toList();
+
+        // Salva no cache
+        await CacheManager.saveCache(_cacheKey, data);
+
+        return _ordenarPorDataDecrescente(informativos);
+      } else {
+        // Se falhar, tenta retornar cache mesmo que expirado
+        try {
+          final cachedData = await CacheManager.getStaleCache(_cacheKey);
+          if (cachedData != null) {
+            final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
+            return _ordenarPorDataDecrescente(
+              data.map((e) => InformativoModel.fromJson(e)).toList()
+            );
+          }
+        } catch (_) {}
+
+        throw Exception('Erro: ${response.statusCode}');
+      }
+    } catch (e) {
+      debugPrint('Erro ao buscar informativos: $e');
+      rethrow;
+    }
   }
 
-  try {
-    final String? token = await SessionManager.getToken();
-    final response = await http.get(
-      Uri.parse('${ApiConfig.baseUrl}/api/Informativo/Grupo'),
-      headers: {
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
-        'Authorization': 'Bearer $token', 
-      },
-    );
+  /// Busca informativos com paginação (otimizado para economizar dados)
+  /// Carrega todos os dados uma vez e implementa paginação localmente
+  Future<PaginatedInformativeResult> getPaginated({
+    int pageNumber = 1,
+    int pageSize = _defaultPageSize,
+  }) async {
+    try {
+      // Carrega todos os informativos (usa cache quando disponível)
+      final allInformativos = await getAll();
 
-    if (response.statusCode == 200) {
-      final List data = jsonDecode(response.body);
-      final informativos = data.map((e) => InformativoModel.fromJson(e)).toList();
-      
-      // Salva no cache
-      await CacheManager.saveCache(_cacheKey, data);
-      
-      return informativos;
-    } else {
-      // Se falhar, tenta retornar cache mesmo que expirado
-      try {
-        final cachedData = await CacheManager.getStaleCache(_cacheKey);
-        if (cachedData != null) {
-          final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
-          return data.map((e) => InformativoModel.fromJson(e)).toList();
-        }
-      } catch (_) {}
-      
-      throw Exception('Erro: ${response.statusCode}');
+      // Calcula índices de paginação
+      final totalItems = allInformativos.length;
+      final startIndex = (pageNumber - 1) * pageSize;
+      final endIndex = (startIndex + pageSize).clamp(0, totalItems);
+
+      // Valida índices
+      if (startIndex >= totalItems && totalItems > 0) {
+        return PaginatedInformativeResult(
+          items: [],
+          pageNumber: pageNumber,
+          pageSize: pageSize,
+          totalItems: totalItems,
+          hasMorePages: false,
+          isFromCache: true,
+        );
+      }
+
+      // Extrai página de dados
+      final pageItems = allInformativos.sublist(
+        startIndex,
+        endIndex,
+      );
+
+      // Verifica se há mais páginas
+      final hasMorePages = endIndex < totalItems;
+
+      // Determina se dados vieram do cache
+      final isCacheValid = await CacheManager.isCacheValid(_cacheKey);
+
+      return PaginatedInformativeResult(
+        items: pageItems,
+        pageNumber: pageNumber,
+        pageSize: pageSize,
+        totalItems: totalItems,
+        hasMorePages: hasMorePages,
+        isFromCache: isCacheValid,
+      );
+    } catch (e) {
+      debugPrint('Erro ao buscar informativos paginados: $e');
+      rethrow;
     }
-  } catch (e) {
-    debugPrint('Erro ao buscar informativos: $e');
-    rethrow;
   }
-}
+
+  /// Ordena informativos por data decrescente (mais recentes primeiro)
+  List<InformativoModel> _ordenarPorDataDecrescente(List<InformativoModel> informativos) {
+    final lista = List<InformativoModel>.from(informativos);
+    lista.sort((a, b) => b.dataInicio.compareTo(a.dataInicio));
+    return lista;
+  }
+
+  /// Força refresh dos dados (limpa cache e busca novamente)
+  /// Use com moderação para economizar dados
+  Future<void> refreshCache() async {
+    await CacheManager.refreshCache(_cacheKey);
+  }
 }


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
1-Exibir avisos mais recentes primeiro;
2-Implementar paginação para buscar novos dados na API apenas se necessário;
3-Priorizar o cache local para poupar o plano de dados do associado.

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x] Exibir avisos mais recentes primeiro
- Ordenação automática e decrescente de informativos por `dataInicio`
- Aplicada em todas as operações (`getAll()` e `getPaginated()`)
- Método dedicado: `_ordenarPorDataDecrescente()`
- [x] Paginação com carregamento sob demanda
- Classe `PaginatedInformativeResult` com suporte a múltiplas páginas
- Carregamento de dados **apenas uma vez** (máxima economia)
- Paginação local com 10 itens por página (configurável)
- Infinite scroll: detecta quando usuário atinge 80% do final da lista
- Proteção contra requisições duplicadas
- [ x] Priorizar o cache local para poupar o plano de dados do associado
- Cache local prioritário
- Cache com duração de **30 minutos** (configurável)
- Timestamps para rastreamento de validade
- Cache isolado por usuário para segurança de dados
- **Fallback inteligente**: em caso de falha de API, retorna dados em cache

## Mudanças Que Não Estavam Previstas
[Caso tenha feito alguma alteração extra que não estava originalmente planejada, descreva-as aqui. Use o checklist markdown como o exemplo abaixo]
- [x] Item 1
- [ ] Item 2 
- [ ] Item 3

## Como Testar
Logar com conta associado e verificar a existência de eventos, logo em seguida desligar a internet do dispositivo fazer logout e logar e depois verificar se as informações persistem sem internet. 

## Prints
[Insira aqui os prints ou screenshots relevantes para mostrar as mudanças realizadas, se aplicável.]



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
