### PR TITLE
Realizado o Ajustar gerenciamento de solicitações de participação em eventos

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarSolicitacaoEvento.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/GerenciarSolicitacaoEvento.cshtml
@@ -38,6 +38,13 @@
         <label asp-for="NomesRegentes" class="control-label"></label>
         <input asp-for="NomesRegentes" readonly class="form-control" />
         <br /><br />
+        
+        <div class="d-flex justify-content-end mb-3">
+            <button type="button" class="btn btn-success" id="btnDeferirTodos">
+                Deferir Todos os Inscritos
+            </button>
+        </div>
+
         <table class="table">
             <thead>
                 <tr class="bg-danger bg-opacity-75 text-white">
@@ -87,7 +94,9 @@
                             </td>
                             <td class="p-3">
                                 <select asp-for="@item.AprovadoModel" class="form-select"
-                                        asp-items="Html.GetEnumSelectList<Core.DTO.InscricaoEventoPessoa>()"
+                                        asp-items="@(new SelectList(Html.GetEnumSelectList<Core.DTO.InscricaoEventoPessoa>()
+                                            .Where(x => x.Text == "DEFERIDO" || x.Text == "INDEFERIDO" || x.Text == "INSCRITO"), 
+                                            "Value", "Text", (int)item.AprovadoModel))"
                                         onchange="updateHiddenInput(this, 'hiddenAprovadoModel_@index')">
                                 </select>
                                 <input type="hidden" id="hiddenAprovadoModel_@index"
@@ -121,4 +130,20 @@
         function updateHiddenInput(selectElement, hiddenInputId) {
             document.getElementById(hiddenInputId).value = selectElement.value
         }
+
+        document.getElementById('btnDeferirTodos').addEventListener('click', function () {
+            const selects = document.querySelectorAll('select.form-select');
+            
+            selects.forEach(function (select) {
+                const options = Array.from(select.options);
+                const inscritoOption = options.find(o => o.text === 'INSCRITO');
+                const deferidoOption = options.find(o => o.text === 'DEFERIDO');
+
+                if (inscritoOption && select.value === inscritoOption.value && deferidoOption) {
+                    select.value = deferidoOption.value;
+                    const event = new Event('change');
+                    select.dispatchEvent(event);
+                }
+            });
+        });
     </script>

--- a/Codigo/Service/EventoService.cs
+++ b/Codigo/Service/EventoService.cs
@@ -521,7 +521,9 @@ namespace Service
                 NomeAssociado = item.NomeAssociado,
                 AprovadoModel = ConvertAprovadoParaEnum(item.Status),
                 Aprovado = ConvertAprovadoParaEnum(item.Status)
-            }).ToList();
+            })
+            .Where(x => x.AprovadoModel != InscricaoEventoPessoa.NAO_SOLICITADO)
+            .ToList();
 
             // Calcular faltas e inadimplência apenas para associados
             for (int i = 0; i < query.Count; i++)


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">   
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
O comportamento atual permite que o status NAO_SOLICITADO apareça na lista de seleção. Porém, esse status não deve ser exibido para o administrador, pois se uma pessoa não solicitou participação, ela não deveria aparecer na lista de solicitações.

## Foi Feito
[Explique as alterações realizadas neste Pull Request de forma detalhada. Use o checklist markdown como o exemplo abaixo]
- [x] A opção NAO_SOLICITADO não deve aparecer no select da tela.
- [x] Pessoas com status NAO_SOLICITADO não devem aparecer na lista de solicitações. 
- [x] Deve existir uma opção geral para deferir todos os inscritos.

## Mudanças Que Não Estavam Previstas
[Caso tenha feito alguma alteração extra que não estava originalmente planejada, descreva-as aqui. Use o checklist markdown como o exemplo abaixo]
- [x] Item 1
- [ ] Item 2 
- [ ] Item 3

## Como Testar
[Forneça instruções claras sobre como testar as alterações feitas neste Pull Request. Inclua comandos, configurações ou procedimentos necessários.]

## Prints
[Insira aqui os prints ou screenshots relevantes para mostrar as mudanças realizadas, se aplicável.]



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
