### PR TITLE
correção da tela esqueceu a senha na aplicação web

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Identity/ForgotPassword.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Identity/ForgotPassword.cshtml
@@ -2,18 +2,18 @@
 @{
     ViewData["Title"] = "Esqueci a senha";
 }
-<div class="card position-absolute top-50 start-50 translate-middle pe-0 col-3 col-sm-8 col-lg-6 col-xxl-3
+<div class="card position-absolute top-50 start-50 translate-middle pe-0 col-11 col-sm-8 col-md-6 col-lg-5 col-xxl-3
                     shadow border-danger border-opacity-75 gray-login">
 
     <div class="d-flex flex-column p-4">
 
-        <h1 class="border-bottom border-dark pb-2 mb-4">
+        <h1 class="border-bottom border-dark pb-2 mb-4 fs-3 fs-md-1">
             Recuperação de senha
         </h1> 
 
         <partial name="_Notificar">
 
-        <p class="fs-5 mb-3 text-justify">
+        <p class="fs-6 fs-md-5 mb-3">
             Para recuperar a sua senha, informe seu endereço de email cadastrado. Logo enviaremos um link para seu email para a alteração da senha.
         </p>
 


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Foi solicitado o ajuste de responsividade da tela de recuperação de senha da aplicação web. Ao diminuir a largura da tela, o conteúdo da página quebrava de forma inadequada, principalmente o texto informativo da tela `ForgotPassword`.

## Foi Feito
- [x] Ajustada a largura responsiva do card da tela de recuperação de senha.
- [x] Corrigidas as classes Bootstrap responsáveis pelo tamanho do card em telas menores.
- [x] Melhorada a exibição do texto em dispositivos com largura reduzida.
- [x] Mantida a estrutura visual original da tela, alterando apenas o necessário para corrigir a responsividade.

## Mudanças Que Não Estavam Previstas
- [x] Nenhuma mudança extra foi realizada além dos ajustes de responsividade.

## Como Testar
1. Acessar a aplicação web.
2. Ir até a tela de recuperação de senha.
3. Reduzir manualmente a largura da janela do navegador.
4. Também é possível testar pelo DevTools do navegador usando visualização mobile.
5. Verificar se o card mantém uma largura adequada em telas menores.
6. Confirmar se o texto não quebra de forma excessiva ou prejudica a leitura.

## Prints
[Insira aqui os prints ou screenshots relevantes para mostrar as mudanças realizadas, se aplicável.]
<img width="516" height="605" alt="image" src="https://github.com/user-attachments/assets/2980dc5e-6f17-448a-9dc2-378b87af9d85" />
<img width="358" height="626" alt="image" src="https://github.com/user-attachments/assets/be97044d-d8c8-4236-ae5e-7902134062c2" />


**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
