### PR TITLE
fix: adicionar queries de navegação para url_launcher no mobile. 

### DIFF
--- a/Codigo/GestaoGrupoMusicalMobile/android/app/src/main/AndroidManifest.xml
+++ b/Codigo/GestaoGrupoMusicalMobile/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,9 @@
         android:label="Batalá"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
-        android:usesCleartextTraffic="true"> <activity
+        android:usesCleartextTraffic="true">
+        
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTop"
@@ -15,20 +17,33 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
+            
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+              android:resource="@style/NormalTheme" />
+              
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
+        
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+
     <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
         <intent>
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>


### PR DESCRIPTION
#933

<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Foi solicitado o ajuste no comportamento dos links de materiais de estudo, pois eles funcionavam corretamente no ambiente Desktop (Windows), mas não abriam o navegador ou aplicativos externos quando executados em dispositivos móveis (Android/iOS). O objetivo deste PR é garantir que a abertura de links externos funcione perfeitamente no Mobile.

## Foi Feito
- [x] Adicionado o bloco `<queries>` no `AndroidManifest.xml` para declarar a intenção de abertura de esquemas `http` e `https`.
- [x] Correção da formatação e recuo das tags nativas dentro do `AndroidManifest.xml`.
- [x] Garantia de conformidade com os requisitos de privacidade e segurança do Android 11+ (API 30+) para interação com o navegador padrão do dispositivo.

## Mudanças Que Não Estavam Previstas
- [x] Organização estrutural do arquivo `AndroidManifest.xml`, corrigindo a quebra de linha da tag `<application>` que estava mal formatada na mesma linha da `<activity>`.

## Como Testar
1. Baixe esta branch localmente.
2. Certifique-se de fechar completamente o aplicativo no seu emulador ou dispositivo físico móvel (**Stop** no terminal/IDE, pois alterações nativas exigem um novo *build* completo).
3. Execute o comando `flutter run`.
4. Vá até a tela de **Materiais de Estudo**.
5. Clique em qualquer card que possua um link.
6. Verifique se o navegador padrão do celular (ou o app correspondente, como o YouTube) abre o link de forma externa com sucesso.

## Prints
[Insira aqui o print da tela do celular com a lista de materiais ou um GIF mostrando o clique no link abrindo o navegador, se possuir.]



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**