### PR TITLE
fix(auth): permitir que regente acesse solicitações de eventos.

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -504,7 +504,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
             return View(statusGeral);
         }
 
-        [Authorize(Roles = "ADMINISTRADOR GRUPO, COLABORADOR")]
+        [Authorize(Roles = "ADMINISTRADOR GRUPO, COLABORADOR, REGENTE")]
         public ActionResult GerenciarSolicitacaoEvento(int id)
         {
             GerenciarSolicitacaoEventoDTO? g = _eventoService.GetSolicitacoesEventoDTO(id, FaltasPessoasEmEnsaioMeses);


### PR DESCRIPTION
close #935

<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Corrigir o problema de autorização na seção de Eventos, onde usuários com a role `REGENTE` eram redirecionados indevidamente para a tela de login ao tentar acessar a área de Solicitações.

O objetivo desta alteração foi garantir que o sistema reconheça corretamente a role do usuário autenticado e permita o acesso às solicitações de eventos sem invalidar a sessão ou bloquear o acesso.

## Foi Feito
- [x] Adicionada a role `REGENTE` no atributo `[Authorize]` da action `GerenciarSolicitacaoEvento`
- [x] Corrigida a validação de autorização para permitir acesso do Regente às solicitações de eventos
- [x] Mantido o controle de acesso existente para as demais roles (`ADMINISTRADOR GRUPO` e `COLABORADOR`)
- [x] Validado o fluxo de navegação sem redirecionamento indevido para `/Login`

## Mudanças Que Não Estavam Previstas
- [x] Revisão do comportamento da autenticação ao acessar páginas protegidas da seção de Eventos
- [ ] Refatoração das permissões em outras controllers
- [ ] Alterações adicionais de layout ou interface

## Como Testar
1. Realizar login com um usuário que possua a role `REGENTE`
2. Acessar a seção de Eventos
3. Clicar na opção de Solicitações
4. Verificar se o sistema permite o acesso normalmente à tela de gerenciamento de solicitações
5. Confirmar que não ocorre redirecionamento para `/Login`

## Prints

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
<img width="1846" height="871" alt="image" src="https://github.com/user-attachments/assets/6f88f8b0-f4d8-4d5b-9bbf-21c77cde6d6c" />
