### PR TITLE
Adiciona tabela para armazenar token FCM por pessoa

### DIFF
--- a/Codigo/Core/DispositivoPessoa.cs
+++ b/Codigo/Core/DispositivoPessoa.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+    namespace Core
+    {
+        public partial class DispositivoPessoa
+        {
+            public int Id { get; set; }
+
+            public int IdPessoa { get; set; }
+
+            public string FcmToken { get; set; } = null!;
+
+            public DateTime DataAtualizacao { get; set; }
+
+            public virtual Pessoa Pessoa { get; set; } = null!;
+        }
+    }

--- a/Codigo/Core/GrupoMusicalContext.cs
+++ b/Codigo/Core/GrupoMusicalContext.cs
@@ -1,6 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Core;
 using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
 
 namespace Core;
 
@@ -58,6 +59,8 @@ public partial class GrupoMusicalContext : DbContext
     public virtual DbSet<Papelgrupo> Papelgrupos { get; set; }
 
     public virtual DbSet<Pessoa> Pessoas { get; set; }
+
+    public virtual DbSet<DispositivoPessoa> DispositivoPessoas { get; set; }
 
     public virtual DbSet<Receitafinanceira> Receitafinanceiras { get; set; }
 
@@ -959,6 +962,35 @@ public partial class GrupoMusicalContext : DbContext
             entity.Property(e => e.Nome)
                 .HasMaxLength(100)
                 .HasColumnName("nome");
+        });
+
+        modelBuilder.Entity<DispositivoPessoa>(entity =>
+        {
+            entity.HasKey(e => e.Id).HasName("PRIMARY");
+
+            entity.ToTable("dispositivopessoa");
+
+            entity.HasIndex(e => e.IdPessoa, "fk_DispositivoPessoa_Pessoa_idx");
+
+            entity.Property(e => e.Id)
+                .HasColumnName("id");
+
+            entity.Property(e => e.IdPessoa)
+                .HasColumnName("idPessoa");
+
+            entity.Property(e => e.FcmToken)
+                .HasColumnType("text")
+                .HasColumnName("fcmToken");
+
+            entity.Property(e => e.DataAtualizacao)
+                .HasColumnType("datetime")
+                .HasColumnName("dataAtualizacao");
+
+            entity.HasOne(d => d.Pessoa)
+                .WithMany()
+                .HasForeignKey(d => d.IdPessoa)
+                .OnDelete(DeleteBehavior.ClientSetNull)
+                .HasConstraintName("fk_DispositivoPessoa_Pessoa");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/Codigo/Core/Migrations/20260604170502_AdicionaTabelaDispositivoPessoa.Designer.cs
+++ b/Codigo/Core/Migrations/20260604170502_AdicionaTabelaDispositivoPessoa.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Core.Migrations
 {
     [DbContext(typeof(GrupoMusicalContext))]
-    partial class GrupoMusicalContextModelSnapshot : ModelSnapshot
+    [Migration("20260604170502_AdicionaTabelaDispositivoPessoa")]
+    partial class AdicionaTabelaDispositivoPessoa
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Codigo/Core/Migrations/20260604170502_AdicionaTabelaDispositivoPessoa.cs
+++ b/Codigo/Core/Migrations/20260604170502_AdicionaTabelaDispositivoPessoa.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MySql.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionaTabelaDispositivoPessoa : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+            migrationBuilder.CreateTable(
+                name: "dispositivopessoa",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                    idPessoa = table.Column<int>(type: "int", nullable: false),
+                    fcmToken = table.Column<string>(type: "text", nullable: false),
+                    dataAtualizacao = table.Column<DateTime>(type: "datetime", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PRIMARY", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_DispositivoPessoa_Pessoa",
+                        column: x => x.idPessoa,
+                        principalTable: "pessoa",
+                        principalColumn: "id");
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "fk_DispositivoPessoa_Pessoa_idx",
+                table: "dispositivopessoa",
+                column: "idPessoa");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dispositivopessoa");
+
+        }
+    }
+}


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Criar a estrutura inicial no backend para permitir o armazenamento do token FCM dos dispositivos vinculados a uma pessoa do sistema.

Essa alteração faz parte da preparação do projeto para a futura implementação de notificações push utilizando Firebase Cloud Messaging no Batalá.

## Foi Feito
- [x] Criada a entidade `DispositivoPessoa` no projeto `Core`.
- [x] Adicionado o `DbSet<DispositivoPessoa>` no `GrupoMusicalContext`.
- [x] Configurado o mapeamento da entidade `DispositivoPessoa` para a tabela `dispositivopessoa`.
- [x] Criada a migration `AdicionaTabelaDispositivoPessoa`.
- [x] Criada a estrutura da tabela `dispositivopessoa` com os campos:
  - [x] `id`
  - [x] `idPessoa`
  - [x] `fcmToken`
  - [x] `dataAtualizacao`
- [x] Configurado o relacionamento entre `dispositivopessoa` e `pessoa`, utilizando `idPessoa` como chave estrangeira.
- [x] Atualizado o `GrupoMusicalContextModelSnapshot` automaticamente pelo Entity Framework.

## Mudanças Que Não Estavam Previstas
- [x] Durante a geração da migration, foi identificada uma inconsistência antiga entre o modelo `Eventopessoa.IdTipoInstrumento` e a estrutura atual do banco de dados.
- [x] A migration foi ajustada para não alterar a tabela `eventopessoa`, mantendo o escopo deste Pull Request somente na criação da tabela `dispositivopessoa`.
- [x] Os arquivos `Designer.cs` e `GrupoMusicalContextModelSnapshot.cs` foram atualizados automaticamente pelo Entity Framework. Apesar de exibirem várias entidades do modelo, a alteração funcional deste PR é apenas a criação da estrutura relacionada a `DispositivoPessoa`.

## Como Testar

### Teste em banco local

1. Baixar a branch deste Pull Request.

2. Conferir se a string de conexão do projeto Web ou API está apontando para o banco local correto.

Exemplo de configuração local:

```json
"ConnectionStrings": {
  "GrupomusicalDatabase": "Server=localhost;Database=grupomusical;Uid=root;Pwd=sua_senha;"
}