### PR TITLE
fix(ensaio): corrigir persistência dos checkboxes e lógica de carregamento da chamada

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EnsaioController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EnsaioController.cs
@@ -277,9 +277,18 @@ namespace GestaoGrupoMusicalWeb.Controllers
             int idGrupoMusical = await _grupoMusical.GetIdGrupo(User.Identity.Name);
 
             var listaAssociadosAtivos = _ensaioService.GetAssociadoAtivos(id);
+
+            // Verifica se é uma lista "nova" (ninguém tem presença ou justificativa registrada ainda)
+            bool isListaNova = !listaAssociadosAtivos.Any(a => a.Presente == 1 || a.JustificativaAceita == 1);
+
             foreach (AssociadoDTO la in listaAssociadosAtivos)
             {
-                la.Presente = 1; 
+                // Se for a primeira vez abrindo a lista, inicia todos como Presente
+                if (isListaNova)
+                {
+                    la.Presente = 1;
+                }
+
                 la.PresenteModel = la.Presente;
                 la.JustificativaAceitaModel = la.JustificativaAceita;
             }
@@ -314,6 +323,8 @@ namespace GestaoGrupoMusicalWeb.Controllers
             }
 
             ensaioView.AssociadosDTO = listaAssociadosAtivos;
+
+            ModelState.Clear();
 
             return View(ensaioView);
         }

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/RegistrarFrequencia.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Ensaio/RegistrarFrequencia.cshtml
@@ -13,7 +13,7 @@
         <ol class="breadcrumb px-3">
             <strong>
                 <a class="text-danger text-opacity-75" asp-action="Index">@ViewData["Ensaio"]</a>
-                <spn class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["Registrar Frequência"]</spn>
+                <span class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["Registrar Frequência"]</span>
             </strong>
         </ol>
     </nav>
@@ -87,8 +87,7 @@
                             {
                                 <tr class="border-bottom border-danger border-opacity-75 p-3 align-middle">
                                     <input type="hidden" name="AssociadosDTO[@i].Id" value="@Model.AssociadosDTO[i].Id" />
-
-                                    <input type="hidden" name="AssociadosDTO[@i].IdPapelGrupo" value="@Model.AssociadosDTO[i].IdPapelGrupo"/>
+                                    <input type="hidden" name="AssociadosDTO[@i].IdPapelGrupo" value="@Model.AssociadosDTO[i].IdPapelGrupo" />
 
                                     <td class="p-3">
                                         @Html.DisplayFor(model => Model.AssociadosDTO[i].Cpf)
@@ -103,14 +102,18 @@
                                     </td>
 
                                     <td class="p-3">
-                                        <input type="checkbox" name="AssociadosDTO[@i].Presente" value="1" @(Model.AssociadosDTO[i].Presente == 1 ? "checked" : "") />
-                                        <input type="hidden" name="AssociadosDTO[@i].Presente" value="0" />
+                                        <input type="checkbox" class="check-presente" data-id="@i"
+                                               @(Model.AssociadosDTO[i].Presente == 1 ? "checked" : "") />
+
+                                        <input type="hidden" id="hdn_presente_@i" name="AssociadosDTO[@i].Presente" value="@Model.AssociadosDTO[i].Presente" />
                                         <input type="hidden" name="AssociadosDTO[@i].PresenteModel" value="@Model.AssociadosDTO[i].PresenteModel" />
                                     </td>
 
                                     <td class="p-3 text-center">
-                                        <input type="checkbox" name="AssociadosDTO[@i].JustificativaAceita" value="1" @(Model.AssociadosDTO[i].JustificativaAceita == 1 ? "checked" : "") />
-                                        <input type="hidden" name="AssociadosDTO[@i].JustificativaAceita" value="0" />
+                                        <input type="checkbox" class="check-justificativa" data-id="@i"
+                                               @(Model.AssociadosDTO[i].JustificativaAceita == 1 ? "checked" : "") />
+
+                                        <input type="hidden" id="hdn_justif_@i" name="AssociadosDTO[@i].JustificativaAceita" value="@Model.AssociadosDTO[i].JustificativaAceita" />
                                         <input type="hidden" name="AssociadosDTO[@i].JustificativaAceitaModel" value="@Model.AssociadosDTO[i].JustificativaAceitaModel" />
                                     </td>
                                 </tr>
@@ -129,11 +132,57 @@
         </div>
     </form>
 
-
-    @section Scripts {
-        @{
-            await Html.RenderPartialAsync("_ValidationScriptsPartial");
-            await Html.RenderPartialAsync("_EnablePopoversPartial");
-            await Html.RenderPartialAsync("_AutoCompletePartial");
-        }
+@section Scripts {
+    @{
+        await Html.RenderPartialAsync("_ValidationScriptsPartial");
+        await Html.RenderPartialAsync("_EnablePopoversPartial");
+        await Html.RenderPartialAsync("_AutoCompletePartial");
     }
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                console.log("Script de frequência carregado com sucesso!");
+
+                const checksPresente = document.querySelectorAll('.check-presente');
+                const checksJustificativa = document.querySelectorAll('.check-justificativa');
+
+                // Lógica ao clicar em PRESENTE
+                checksPresente.forEach(function (chk) {
+                    chk.addEventListener('change', function () {
+                        const index = this.getAttribute('data-id');
+                        console.log("Clicou em presente. Linha: " + index);
+
+                        const hdnPresente = document.getElementById('hdn_presente_' + index);
+                        const chkJustif = document.querySelector('.check-justificativa[data-id="' + index + '"]');
+                        const hdnJustif = document.getElementById('hdn_justif_' + index);
+
+                        hdnPresente.value = this.checked ? "1" : "0";
+
+                        if (this.checked && chkJustif) {
+                            chkJustif.checked = false; // Desmarca na tela
+                            hdnJustif.value = "0";     // Zera no banco
+                        }
+                    });
+                });
+
+                // Lógica ao clicar em JUSTIFICATIVA
+                checksJustificativa.forEach(function (chk) {
+                    chk.addEventListener('change', function () {
+                        const index = this.getAttribute('data-id');
+                        console.log("Clicou em justificativa. Linha: " + index);
+
+                        const hdnJustif = document.getElementById('hdn_justif_' + index);
+                        const chkPresente = document.querySelector('.check-presente[data-id="' + index + '"]');
+                        const hdnPresente = document.getElementById('hdn_presente_' + index);
+
+                        hdnJustif.value = this.checked ? "1" : "0";
+
+                        if (this.checked && chkPresente) {
+                            chkPresente.checked = false; // Desmarca na tela
+                            hdnPresente.value = "0";     // Zera no banco
+                        }
+                    });
+                });
+            });
+        </script>
+}


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Corrigir o bug visual na tela de Registrar Frequência de Ensaio, onde as caixas de "Presente" e "Justificativa Aceita" ficavam marcadas simultaneamente após o salvamento. Além disso, foi solicitado garantir que, ao abrir a chamada de um ensaio pela primeira vez, todos os associados venham marcados como "Presente" por padrão, mas que o sistema respeite e mantenha o estado real salvo no banco de dados nas aberturas subsequentes.

## Foi Feito
- [x] Desacoplamento dos checkboxes visuais do Model Binder do ASP.NET (remoção do atributo `name` e substituição por `data-id`).
- [x] Implementação de script JavaScript (Vanilla JS) para gerenciar o estado das opções mutuamente exclusivas e preencher os campos `hidden` de forma correta (enviando estritamente "0" ou "1").
- [x] Adição do método `ModelState.Clear()` no POST do `EnsaioController` para limpar o cache de formulário e evitar o recarregamento de opções "fantasmas".
- [x] Implementação de uma heurística (variável `isListaNova`) no GET do `EnsaioController` para marcar presença automática apenas se for a primeira vez que a lista de frequência daquele ensaio é aberta.

## Mudanças Que Não Estavam Previstas
- [x] Correção de um erro de digitação na tag HTML do *breadcrumb* na View (alterado de `<spn>` para `<span>`).
- [x] Remoção da atribuição estática `la.Presente = 1;` dentro do laço `foreach` no Controller, que estava sobreescrevendo o estado vindo do banco de dados (ignorando as faltas já salvas).

## Como Testar
1. Inicie a aplicação localmente.
2. Navegue até o módulo de **Ensaios**.
3. Escolha um ensaio recém-criado (cuja chamada ainda não foi feita) e clique em **Registrar Frequência**.
4. Verifique se **todos** os associados aparecem com a caixa "Presente" marcada.
5. Altere o estado de alguns associados (desmarque presença, marque justificativa aceita) e clique em **Salvar**.
6. Verifique se a tela recarrega mantendo **exatamente** as opções que você marcou, sem sobrepor os checkboxes de Presença e Justificativa na mesma linha.
7. Abra a frequência de um ensaio antigo (já salvo) e garanta que o sistema carrega o histórico real, sem forçar a presença de todos.

## Prints
<img width="1650" height="692" alt="image" src="https://github.com/user-attachments/assets/91c661a2-2ec7-4279-bfd4-f39a2a394de5" />


**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**