### PR TITLE
fix: resolve InvalidOperationException em eventos e ensaios

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -381,7 +381,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                 return RedirectToAction("MeusEventos");
             }
 
-            var instrumentosDisponiveis = _eventoService.GetInstrumentosDisponiveisAsync(id);
+            var instrumentosDisponiveis = await _eventoService.GetInstrumentosDisponiveisAsync(id);
             var minhaInscricao = await _eventoService.GetSolicitacaoAssociado(id, idPessoa);
 
             var model = new EventoDetalhesAssociadoDTO
@@ -391,7 +391,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                 DataHoraFim = evento.DataHoraFim,
                 Local = evento.Local,
                 Repertorio = evento.Repertorio,
-                InstrumentosDisponiveis = await instrumentosDisponiveis,
+                InstrumentosDisponiveis = instrumentosDisponiveis,
                 MinhaInscricao = minhaInscricao,
                 PodeInscrever = minhaInscricao == null || minhaInscricao.StatusEnum == InscricaoEventoPessoa.NAO_SOLICITADO,
                 PodeCancelar = minhaInscricao?.StatusEnum == InscricaoEventoPessoa.INSCRITO


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Resolver a exceção `InvalidOperationException` que ocorria intermitentemente nos fluxos de visualização de detalhes e inscrição em eventos. O erro era causado pelo acesso concorrente a uma única instância do `DbContext` durante chamadas assíncronas não aguardadas.

## Foi Feito
- [x] Identificação do ponto de concorrência no `EventoController`.
- [x] Adição do operador `await` na chamada do método `_eventoService.GetInstrumentosDisponiveisAsync(id)`.
- [x] Garantia de execução sequencial das tarefas assíncronas para evitar conflitos no `DbContext`.

## Mudanças Que Não Estavam Previstas
- [x] Revisão pontual da assinatura e consumo das tarefas no `EventoController` para garantir compatibilidade com o fluxo assíncrono corrigido.

## Como Testar
1. Suba a aplicação localmente e acesse a conta de associado (ex: `32122777508`).
2. Navegue até **Eventos e Ensaios** -> **Ensaios**.
3. Clique no botão de **Detalhes** do evento.
4. Clique no botão **"Quero participar"**.
5. Verifique se a página carrega corretamente sem exibir a tela de *Internal Server Error* referente ao `InvalidOperationException`.

## Prints
<img width="1848" height="872" alt="image" src="https://github.com/user-attachments/assets/19c8b99f-695e-4c6f-b488-e6c374cdef04" />
<img width="1863" height="808" alt="image" src="https://github.com/user-attachments/assets/e35b9f00-22c3-4384-9a0d-69823e98fbe6" />

---
**Closes #947, #949**

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**