### PR TITLE
Fix do erro que não deixava marcado quem era o regente no edit de evento

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -177,6 +177,7 @@ namespace GestaoGrupoMusicalWeb.Controllers
                 DataHoraFim = evento.DataHoraFim,
                 Local = evento.Local,
                 Repertorio = evento.Repertorio,
+                IdRegentes = await _eventoService.GetIdRegentesEventoAsync(evento.Id),
                 ListaPessoa = new SelectList(listaPessoasAutoComplete, "Id", "Nome"),
                 FigurinoList = new SelectList(figurinosDropdown, "Id", "Nome")
             };

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
@@ -4,6 +4,10 @@
     ViewData["Title"] = "Editar Evento";
     ViewData["Evento"] = "Evento";
     ViewData["Edit"] = "Editar";
+
+    var regentesSelecionados = Model.IdRegentes?
+        .Select(id => id.ToString())
+        .ToHashSet() ?? new HashSet<string>();
 }
 
 <hr />
@@ -49,6 +53,7 @@
                                                type="checkbox"
                                                value="@regente.Value"
                                                id="regente_@regente.Value"
+                                               checked="@regentesSelecionados.Contains(regente.Value)"
                                                onchange="updateRegenteSelection()">
                                         <label class="form-check-label" for="regente_@regente.Value">
                                             @regente.Text
@@ -142,12 +147,7 @@
     document.addEventListener('DOMContentLoaded', function () {
         updateCharacterCountLocal();
         updateCharacterCountRepertorio();
-    });
-</script>
-
-<script>
-    window.addEventListener("load", () => {
-        fillAutocomplete('@(Html.Raw(Model.JsonLista))', "regentes", "IdRegentes", "formEdit", "O campo Regentes é obrigatório");
+        updateRegenteSelection();
     });
 </script>
 


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado

Foi solicitado corrigir o problema na tela de edição de eventos, onde o regente associado ao evento não estava sendo exibido corretamente ao acessar pela conta verynice.

## Foi Feito

* [x] Corrigido o carregamento do regente associado na tela de editar evento.
* [x] Ajustada a exibição do regente para que apareça corretamente no formulário de edição.
* [x] Verificado que o regente já era exibido corretamente na tela de informações do evento.
* [x] Testado o acesso pelo caminho Eventos > Editar utilizando a conta verynice.

## Mudanças Que Não Estavam Previstas

* [x] Foi necessário revisar a forma como o regente associado estava sendo carregado na tela de edição.
* [x] Foi feita a comparação com a tela de informações do evento, onde o regente já aparecia corretamente.

## Como Testar

1. Executar o projeto localmente.
2. Fazer login com a conta verynice.
3. Acessar o menu de eventos.
4. Selecionar um evento que possua regente associado.
5. Clicar em editar.
6. Verificar se o regente associado aparece corretamente na tela de edição.
7. Acessar também a opção informações do mesmo evento e conferir se o regente exibido é o mesmo.

## Prints

[Inserir aqui os prints da tela de edição do evento mostrando o regente associado corretamente.]
<img width="1056" height="757" alt="image" src="https://github.com/user-attachments/assets/fdf759a2-8882-46fe-a8be-e26c035bbd9b" />
<img width="1472" height="691" alt="image" src="https://github.com/user-attachments/assets/208036dd-1d19-44a4-b25b-5a6733a7ed67" />

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
