### PR TITLE
fix(evento): Corrigir quebra de layout e fechamento de tags na edição

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
@@ -13,12 +13,12 @@
 <hr />
 <div class="row">
     <div class="col-md-8">
-        <h1 class="p-3 bg-danger  bg-opacity-75 text-white fs-5">Editar Evento Musical</h1>
+        <h1 class="p-3 bg-danger bg-opacity-75 text-white fs-5">Editar Evento Musical</h1>
         <nav>
             <ol class="breadcrumb px-3">
                 <strong>
                     <a class="text-danger text-opacity-75" asp-action="Index">@ViewData["Evento"]</a>
-                    <spn class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["Edit"]</spn>
+                    <span class="text-secondary"><i class="text-dark fa-sharp fa-solid fa-angle-right fa-xs"></i> @ViewData["Edit"]</span>
                 </strong>
             </ol>
         </nav>
@@ -65,13 +65,14 @@
                             {
                                 <p class="text-muted">Nenhum regente cadastrado</p>
                             }
-                    </div>
+                        </div>
                         <select multiple asp-for="IdRegentes" class="d-none" id="hiddenRegenteSelect">
                         </select>
                         <span asp-validation-for="IdRegentes" class="text-danger"></span>
                         <small class="form-text text-muted">
                             <span id="regenteCount">0</span> regente(s) selecionado(s)
                         </small>
+                    </div>
                 </div>
             </div>
             <div class="container">
@@ -101,10 +102,10 @@
             <br />
             <br />
             <div class="container">
-                <div class="row d-flex flex-column-reverse d-grig gap-2 mx-auto d-flex flex-sm-column-reverse flex-xl-row">
+                <div class="row d-flex flex-column-reverse d-grid gap-2 mx-auto d-flex flex-sm-column-reverse flex-xl-row">
                     <div class="col-5 d-none d-sm-block"></div>
                     <a class="btn btn-light text-secondary border border-secondary d-grid gap-2 col-sm" asp-controller="Evento" asp-action="Index"> Voltar </a>
-                    <input type="submit" value="Salvar" class="btn btn-secondary d-grid gap-2 col-sm " />
+                    <input type="submit" value="Salvar" class="btn btn-secondary d-grid gap-2 col-sm" />
                 </div>
             </div>
         </form>
@@ -112,21 +113,20 @@
 </div>
 
 <script>
-
     function updateRegenteSelection() {
         const checkboxes = document.querySelectorAll('.regente-checkbox:checked');
         const hiddenSelect = document.getElementById('hiddenRegenteSelect');
         const countSpan = document.getElementById('regenteCount');
-        // Limpar options existentes
+
         hiddenSelect.innerHTML = '';
-        // Adicionar options para cada checkbox marcado
+
         checkboxes.forEach(checkbox => {
             const option = document.createElement('option');
             option.value = checkbox.value;
             option.selected = true;
             hiddenSelect.appendChild(option);
         });
-        // Atualizar contador
+
         countSpan.textContent = checkboxes.length;
     }
 


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Correção de bug visual na tela de **Editar Evento Musical**, onde o layout quebrava e o rodapé/elementos finais da página eram renderizados incorretamente no canto superior direito. O objetivo é restaurar a estrutura correta do DOM e garantir a responsividade dos botões de ação.

## Foi Feito
- [x] Correção da tag HTML inválida `<spn>` para `<span>` na estrutura do breadcrumb (linha 21).
- [x] Correção da classe utilitária do Bootstrap de `d-grig` para `d-grid` na div que encapsula os botões do formulário (linha 71).
- [x] Verificação do fechamento de tags do formulário para garantir que a árvore do DOM seja montada corretamente pelo navegador.

## Mudanças Que Não Estavam Previstas
- [x] Correção do erro de digitação na classe `d-grid` dos botões (identificado durante a inspeção do código para resolver o problema principal da tag aberta).

## Como Testar
1. Baixe esta branch localmente e execute o projeto `GestaoGrupoMusicalWeb`.
2. Faça login no sistema com um perfil que tenha permissão de gerenciamento (ex: Administrador de Grupo).
3. No menu lateral, navegue até a seção de **Eventos**.
4. Clique em **Editar** em qualquer evento musical existente.
5. Verifique se o layout da página renderiza corretamente, se os botões "Voltar" e "Salvar" estão posicionados de forma responsiva ao final do formulário e se o rodapé do sistema permanece fixado no local correto (sem flutuar no topo direito).

## Prints

<img width="1477" height="705" alt="image" src="https://github.com/user-attachments/assets/4beb4fc9-8de2-49ab-807d-e9c4e9e4aeda" />
<img width="1475" height="708" alt="image" src="https://github.com/user-attachments/assets/82e919e2-35bf-4bea-a98b-6db08d57af8d" />

