### PR TITLE
style(perfil): Padronizar botão de "Alterar Senha" e ajustar alinhamento do footer

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/Identity/Perfil.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Identity/Perfil.cshtml
@@ -135,18 +135,20 @@
                             </div>
                         </div>
                     </div>
-                    <div class="card-footer d-flex justify-content-end gap-2">
-                        <button id="editButton" type="button" class="btn btn-secondary btn-sm m-2 view-mode">
-                            <i class="fa-solid fa-pen-to-square"></i> Editar
+                    <div class="card-footer d-flex justify-content-end align-items-center gap-2 py-3">
+                        <button id="editButton" type="button" class="btn btn-secondary btn-sm view-mode">
+                            <i class="fa-solid fa-pen-to-square me-1"></i> Editar
                         </button>
-                        <button id="cancelButton" type="button" class="btn btn-outline-secondary edit-mode">
+
+                        <button type="button" class="btn btn-outline-secondary btn-sm view-mode" data-bs-toggle="modal" data-bs-target="#changePasswordModal">
+                            <i class="fa-solid fa-key me-1"></i> Alterar Senha
+                        </button>
+
+                        <button id="cancelButton" type="button" class="btn btn-outline-secondary btn-sm edit-mode">
                             Cancelar
                         </button>
-                        <button id="saveButton" type="submit" class="btn btn-secondary edit-mode">
-                            <i class="fa-solid fa-check"></i> Salvar
-                        </button>
-                        <button type="button" class="btn btn-outline-danger btn-sm view-mode" data-bs-toggle="modal" data-bs-target="#changePasswordModal">
-                            <i class="fa-solid fa-key"></i> Alterar Senha
+                        <button id="saveButton" type="submit" class="btn btn-secondary btn-sm edit-mode">
+                            <i class="fa-solid fa-check me-1"></i> Salvar
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Padronização visual e correção de tamanho/alinhamento do botão **"Alterar Senha"** na tela de **Meu Perfil** para manter a consistência estética com o botão "Editar".

## Foi Feito
- [x] Alterada a classe do botão de `btn-outline-danger` para `btn-outline-secondary` para remover o vermelho destoante e adotar o padrão neutro do sistema.
- [x] Adicionada a classe `btn-sm` ao botão para corrigir o tamanho gigante e igualar à altura do botão "Editar".
- [x] Ajustado o container pai (`card-footer`) com `align-items-center` e `py-3` para remover margens manuais antigas e centralizar perfeitamente os elementos verticalmente.
- [x] Adicionado espaçamento lateral (`me-1`) nos ícones internos dos botões.

## Mudanças Que Não Estavam Previstas
- [x] Ajuste de alinhamento vertical no flexbox do `card-footer` para evitar que futuras alterações estiquem os botões novamente.

## Como Testar
1. Acesse o sistema e Conta Verynice > canto superior direito "Meus Dados"
2. No modo de visualização dos dados, verifique se os botões **Editar** e **Alterar Senha** estão alinhados, com a mesma altura (`btn-sm`) e com espaçamentos coerentes.
3. Clique em "Cancelar" ou mude os estados para garantir que a transição de classes do JS não quebre o tamanho deles.

## Prints
[Insira aqui o print do botão corrigido]


<img width="332" height="202" alt="image" src="https://github.com/user-attachments/assets/db07a017-0794-450f-8343-4050830c3552" />
