### PR TITLE
Correção do Evento onde não aparecia os regentes apos não escolher ne…

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalWeb/Controllers/EventoController.cs
@@ -225,11 +225,22 @@ namespace GestaoGrupoMusicalWeb.Controllers
             {
                 Notificar("<b>Erro</b>! Verifique os dados do formulário.", Notifica.Erro);
             }
-            // Recarregar os dados necessários para a view em caso de erro
+            // Recarregar os dados necessários para a view em caso de erro.
+            // Isso evita que a lista de regentes desapareça após uma validação inválida.
+            if (eventoModel.IdGrupoMusical == 0 && eventoModel.Id != 0)
+            {
+                var eventoOriginal = _eventoService.Get(eventoModel.Id);
+                eventoModel.IdGrupoMusical = eventoOriginal?.IdGrupoMusical ?? 0;
+            }
+
             var listaPessoasAutoComplete = _pessoaService.GetRegentesForAutoComplete(eventoModel.IdGrupoMusical);
             var figurinosDropdown = await _figurinoService.GetAllFigurinoDropdown(eventoModel.IdGrupoMusical);
+
             eventoModel.ListaPessoa = new SelectList(listaPessoasAutoComplete, "Id", "Nome");
-            eventoModel.FigurinoList = new SelectList(figurinosDropdown, "Id", "Nome");
+            eventoModel.FigurinoList = new SelectList(figurinosDropdown, "Id", "Nome", eventoModel.IdFigurinoSelecionado);
+            eventoModel.JsonLista = listaPessoasAutoComplete.ToJson();
+            ViewData["exemploRegente"] = listaPessoasAutoComplete.Select(p => p.Nome).FirstOrDefault()?.Split(" ")[0];
+
             return View(eventoModel);
         }
 

--- a/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/Evento/Edit.cshtml
@@ -25,6 +25,8 @@
         <hr />
         <br />
         <form id="formEdit" asp-action="Edit">
+                <input type="hidden" asp-for="Id" />
+                <input type="hidden" asp-for="IdGrupoMusical" />
             <div class="container">
                 <div class="row">
                     <div class="form-group col-xxl-4">


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado

Foi solicitada a correção de um problema na tela de edição de eventos, onde ao tentar salvar um evento sem selecionar nenhum regente, o sistema exibia corretamente a mensagem informando que o campo Regentes era obrigatório, porém a lista de regentes deixava de aparecer na tela.

Com isso, o usuário não conseguia selecionar um regente após a validação e precisava voltar para a página anterior e abrir novamente a tela de edição do evento para que os regentes fossem carregados novamente.

## Foi Feito

* [x] Corrigido o carregamento da lista de regentes após uma tentativa inválida de salvar a edição do evento.
* [x] Ajustado o formulário de edição de evento para manter as informações necessárias do evento durante o envio do formulário.
* [x] Adicionados campos ocultos para preservar o identificador do evento e o identificador do grupo musical.
* [x] Ajustado o retorno da tela de edição para recarregar corretamente os dados necessários quando houver erro de validação.
* [x] Garantido que, ao exibir a mensagem de campo obrigatório para Regentes, a lista de regentes continue disponível para seleção.
* [x] Mantido o comportamento esperado da validação, impedindo o salvamento do evento sem regente.

## Mudanças Que Não Estavam Previstas

* [x] Foi identificado que, além da lista de regentes não ser recarregada corretamente, era necessário preservar informações do evento no formulário para evitar perda de dados durante o retorno da validação.
* [x] Foi realizado ajuste preventivo para manter o carregamento correto dos dados auxiliares da tela de edição após erro de validação.

## Como Testar

1. Rodar o projeto localmente.
2. Acessar o sistema com um usuário que tenha permissão para editar eventos.
3. Ir até o menu **Eventos**.
4. Clicar em **Editar** em um evento existente.
5. Remover o regente selecionado ou deixar o campo de regentes sem nenhuma seleção.
6. Clicar em **Salvar**.
7. Verificar se o sistema exibe a mensagem informando que o campo **Regentes** é obrigatório.
8. Verificar se, mesmo após a mensagem de erro, a lista de regentes continua aparecendo normalmente para seleção.
9. Selecionar um regente na lista.
10. Clicar novamente em **Salvar**.
11. Confirmar que o evento é salvo corretamente sem a necessidade de voltar para a página anterior ou abrir novamente a tela de edição.

## Prints

Insira aqui os prints mostrando:

<img width="1061" height="805" alt="image" src="https://github.com/user-attachments/assets/b5c8973d-9ac3-4f8d-b9bf-b076327ccadc" />

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
