### PR TITLE
feat(web): implementar contador de caracteres em MaterialEstudo

### DIFF
--- a/Codigo/GestaoGrupoMusicalWeb/Views/MaterialEstudo/Create.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/MaterialEstudo/Create.cshtml
@@ -26,16 +26,17 @@
                     <div class="row d-flex justify-content-between ">
                         <div class="form-group col-md-12">
                             <label asp-for="Nome" class="control-label"></label>
-                            <input asp-for="Nome" class="form-control" />
+                            <textarea asp-for="Nome" class="form-control" maxlength="200" id="nomeTextArea" oninput="updateCounter('nomeTextArea', 'countNome')"></textarea>
                             <span asp-validation-for="Nome" class="text-danger"></span>
+                            <small id="countNome">0/200</small>
                         </div>
                     </div>
                     <div class="row d-flex justify-content-between">
                         <div class="form-group col-md-12">
                             <label asp-for="Link" class="control-label"></label>
-                            <textarea asp-for="Link" class="form-control" maxlength="500" id="linkTextArea" oninput="updateCharacterCount()"></textarea>
+                            <textarea asp-for="Link" class="form-control" maxlength="500" id="linkTextArea" oninput="updateCounter('linkTextArea', 'countLink')"></textarea>
                             <span asp-validation-for="Link" class="text-danger"></span>
-                            <small id="characterCount">0/500</small>
+                            <small id="countLink">0/500</small>
                         </div>
                     </div>
                 </div>
@@ -57,14 +58,16 @@
         }
     }
     <script>
-        function updateCharacterCount() {
-            var textArea = document.getElementById('linkTextArea');
+        function updateCounter(textAreaId, counterId) {
+            var textArea = document.getElementById(textAreaId);
+            var counter = document.getElementById(counterId);
             var charCount = textArea.value.length;
-            var charLimitFromGrupoMusical = textArea.maxLength;
-            document.getElementById('characterCount').innerText = charCount + '/' + charLimitFromGrupoMusical;
+            var charLimit = textArea.maxLength;
+            counter.innerText = charCount + '/' + charLimit;
         }
 
         document.addEventListener('DOMContentLoaded', function () {
-            updateCharacterCount();
+            updateCounter('nomeTextArea', 'countNome');
+            updateCounter('linkTextArea', 'countLink');
         });
     </script>

--- a/Codigo/GestaoGrupoMusicalWeb/Views/MaterialEstudo/Edit.cshtml
+++ b/Codigo/GestaoGrupoMusicalWeb/Views/MaterialEstudo/Edit.cshtml
@@ -27,14 +27,15 @@
             </div>
             <div class="form-group col-xl">
                 <label asp-for="Nome" class="control-label"></label>
-                <input asp-for="Nome" class="form-control" />
+                <textarea asp-for="Nome" class="form-control" maxlength="200" id="nomeTextArea" oninput="updateCounter('nomeTextArea', 'countNome')"></textarea>
                 <span asp-validation-for="Nome" class="text-danger"></span>
+                <small id="countNome">0/200</small>
             </div>
             <div class="form-group col-md-12">
                 <label asp-for="Link" class="control-label"></label>
-                <textarea asp-for="Link" class="form-control" maxlength="500" id="linkTextArea" oninput="updateCharacterCount()"></textarea>
+                <textarea asp-for="Link" class="form-control" maxlength="500" id="linkTextArea" oninput="updateCounter('linkTextArea', 'countLink')"></textarea>
                 <span asp-validation-for="Link" class="text-danger"></span>
-                <small id="characterCount">0/500</small>
+                <small id="countLink">0/500</small>
             </div>
             <div class="form-group">
                 <input asp-for="IdGrupoMusical" class="form-control" type="hidden" />
@@ -61,14 +62,16 @@
     }
 }
 <script>
-    function updateCharacterCount() {
-        var textArea = document.getElementById('linkTextArea');
+    function updateCounter(textAreaId, counterId) {
+        var textArea = document.getElementById(textAreaId);
+        var counter = document.getElementById(counterId);
         var charCount = textArea.value.length;
-        var charLimitFromGrupoMusical = textArea.maxLength;
-        document.getElementById('characterCount').innerText = charCount + '/' + charLimitFromGrupoMusical;
+        var charLimit = textArea.maxLength;
+        counter.innerText = charCount + '/' + charLimit;
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        updateCharacterCount();
+        updateCounter('nomeTextArea', 'countNome');
+        updateCounter('linkTextArea', 'countLink');
     });
 </script>


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
Implementar um limitador e um contador de caracteres dinâmico nos campos de texto (Título/Nome e Link) da entidade `MaterialEstudo` para melhorar a experiência do usuário e garantir a integridade dos dados conforme os limites do banco de dados.

## Foi Feito
- [x] Adicionado script JavaScript genérico para contagem de caracteres em tempo real.
- [x] Atualizada a view `Create.cshtml` de `MaterialEstudo` com IDs únicos e contadores de caracteres.
- [x] Atualizada a view `Edit.cshtml` de `MaterialEstudo` com IDs únicos e contadores de caracteres.
- [x] Padronizado o uso de `<textarea>` para os campos de texto.

## Mudanças Que Não Estavam Previstas
- [x] Correção de IDs duplicados que estavam impedindo o funcionamento do contador de caracteres.
- [x] Remoção de elementos `input` redundantes que estavam conflitando com os novos `textarea`.

## Como Testar
1. Navegue até a página de **Adicionar Material de Estudo** (`/MaterialEstudo/Create`) ou **Editar Material de Estudo** (`/MaterialEstudo/Edit/{id}`).
2. Digite nos campos "Nome" e "Link".
3. Observe que o contador abaixo de cada campo (ex: `0/200` para Nome e `0/500` para Link) atualiza conforme o texto é inserido.
4. Tente exceder o limite de caracteres definido no `maxlength` e verifique se o navegador impede a inserção de texto adicional.

## Prints
<img width="1855" height="738" alt="image" src="https://github.com/user-attachments/assets/a2c1f75f-3c36-4c3d-895c-32597a6ae31b" />
<img width="1864" height="685" alt="image" src="https://github.com/user-attachments/assets/27274c4f-f78e-475c-998d-86955928e85e" />
<img width="480" height="362" alt="happy homer simpson GIF" src="https://github.com/user-attachments/assets/81b84f71-e18c-483f-8ac9-80e8cf06659d" />