### PR TITLE
fix: dados novos nao atualizam no refresh

### DIFF
--- a/Codigo/GestaoGrupoMusicalMobile/lib/screens/home_view.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/screens/home_view.dart
@@ -1,3 +1,4 @@
+import 'package:batala_mobile/config/cache_service.dart';
 import 'package:flutter/material.dart';
 import 'package:batala_mobile/config/app_colors.dart';
 import 'package:intl/intl.dart';
@@ -6,6 +7,7 @@ import '../model/ensaio_model.dart';
 import '../model/evento_model.dart';
 import '../service/evento_service.dart';
 import '../service/ensaio_service.dart';
+
 
 class HomeView extends StatefulWidget {
   const HomeView({super.key});
@@ -56,11 +58,15 @@ class _HomeViewState extends State<HomeView> {
   }
 
   Future<void> _onRefresh() async {
+    await _eventoService.limparCacheListagem();
+    await _ensaioService.limparCacheListagem();
+
+    // 2. ATUALIZA A TELA E RECARREGA OS DADOS
     setState(() {
       _eventosLimit = 3;
       _ensaiosLimit = 3;
-      _detalhesCache.clear(); // Limpa o cache ao recarregar a tela
-      _carregarDados();
+      _detalhesCache.clear(); // Mantém a limpeza do cache de memória dos detalhes
+      _carregarDados(); // Agora sim, os services serão forçados a fazer o GET na API
     });
   }
 

--- a/Codigo/GestaoGrupoMusicalMobile/lib/service/ensaio_service.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/service/ensaio_service.dart
@@ -1,5 +1,5 @@
+import 'package:batala_mobile/config/session_manager.dart';
 import 'dart:convert';
-
 import 'package:batala_mobile/config/api_config.dart';
 import 'package:batala_mobile/config/cache_manager.dart';
 import 'package:batala_mobile/model/ensaio_model.dart';
@@ -12,11 +12,13 @@ class EnsaioService {
    static const String _cacheKey = 'ensaio_list';
 
   Future<List<EnsaioModel>> getAll() async {
+    final userId = (await SessionManager.getIdPessoa())?.toString();
+
     try {
       // Tenta recuperar do cache primeiro
-      final cachedData = await CacheManager.getCache(_cacheKey);
+      final cachedData = await CacheManager.getCache(_cacheKey, userId: userId);
       if (cachedData != null) {
-        debugPrint('Usando dados em cache para ensaios');
+        debugPrint('Usando dados em cache isolados para ensaios do usuário $userId');
         final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
         return data.map((e) => EnsaioModel.fromJson(e)).toList();
       }
@@ -55,6 +57,15 @@ class EnsaioService {
         }
       } catch (_) {}
       rethrow;
+    }
+  }
+  Future<void> limparCacheListagem() async {
+    final userId = (await SessionManager.getIdPessoa())?.toString();
+    
+    try {
+      await CacheManager.clearCache(_cacheKey, userId: userId);
+    } catch (e) {
+      debugPrint('Erro ao limpar cache: $e');
     }
   }
 }

--- a/Codigo/GestaoGrupoMusicalMobile/lib/service/evento_service.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/service/evento_service.dart
@@ -131,4 +131,15 @@ class EventoService {
       return false;
     }
   }
+
+  // Novo método para forçar a limpeza do cache de eventos
+  Future<void> limparCacheListagem() async {
+    final userId = (await SessionManager.getIdPessoa())?.toString();
+    
+    try {
+      await CacheManager.clearCache(_cacheKey, userId: userId);
+    } catch (e) {
+      debugPrint('Erro ao limpar cache de eventos: $e');
+    }
+  }
 }


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado
No Mobile, os eventos não atualizavam quando o usuário realizava o refresh (puxar a tela para baixo) na HomeView, forçando o usuário a fazer logout e login novamente para buscar os dados atualizados.

## Foi Feito
- [x] Criação do método `limparCacheListagem()` no EventoService e EnsaioService do Mobile para limpar corretamente o cache específico e isolado do usuário logado.
- [x] Atualização da função `_onRefresh` na HomeView do Mobile para invocar a limpeza correta do cache de eventos e ensaios antes de disparar a nova requisição HTTP.

## Mudanças Que Não Estavam Previstas
- [x] Refatoração do EnsaioService (Mobile) para padronizar a arquitetura, implementando o mesmo sistema de cache isolado por usuário (userId) utilizado nos eventos (melhorando a segurança caso múltiplos usuários usem o mesmo aparelho).

## Como Testar
Teste no Backend / Web:

1.    Acesse o painel administrativo do site.

2.    Vá na tela de cadastro de um Novo Evento.

3.    Preencha todos os dados (Regentes, Datas, etc.) e clique em Salvar.

4.    O sistema deve exibir a mensagem de sucesso e o evento deve constar na listagem.

Teste no Mobile (Flutter):

1.    Abra o aplicativo e faça o login com a sua conta.

2.    Na tela inicial (HomeView), visualize a lista atual de eventos.

3.    Sem fechar o aplicativo ou deslogar, crie um novo evento pelo painel Web (como no teste acima).

4.   Volte para o aplicativo e faça o movimento de _pull-to-refresh_ (puxar a tela para baixo).

5.   O novo evento criado no painel Web deve aparecer imediatamente na listagem da tela principal.



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
