### PR TITLE
fix: evita notificações duplicadas e exibe push em primeiro plano

### DIFF
--- a/AnaliseProjeto/AtualizaTokenDispositivoUnico.sql
+++ b/AnaliseProjeto/AtualizaTokenDispositivoUnico.sql
@@ -1,0 +1,16 @@
+SET SQL_SAFE_UPDATES = 0;
+
+DELETE antigo
+FROM dispositivopessoa antigo
+INNER JOIN dispositivopessoa recente
+    ON antigo.fcmToken = recente.fcmToken
+    AND antigo.id < recente.id;
+
+ALTER TABLE dispositivopessoa
+MODIFY COLUMN fcmToken VARCHAR(512) NOT NULL;
+
+ALTER TABLE dispositivopessoa
+ADD CONSTRAINT uq_dispositivopessoa_fcmToken
+UNIQUE (fcmToken);
+
+SET SQL_SAFE_UPDATES = 1;

--- a/Codigo/Core/GrupoMusicalContext.cs
+++ b/Codigo/Core/GrupoMusicalContext.cs
@@ -972,6 +972,9 @@ public partial class GrupoMusicalContext : DbContext
 
             entity.HasIndex(e => e.IdPessoa, "fk_DispositivoPessoa_Pessoa_idx");
 
+            entity.HasIndex(e => e.FcmToken, "uq_dispositivopessoa_fcmToken")
+                .IsUnique();
+
             entity.Property(e => e.Id)
                 .HasColumnName("id");
 
@@ -979,7 +982,7 @@ public partial class GrupoMusicalContext : DbContext
                 .HasColumnName("idPessoa");
 
             entity.Property(e => e.FcmToken)
-                .HasColumnType("text")
+                .HasMaxLength(512)
                 .HasColumnName("fcmToken");
 
             entity.Property(e => e.DataAtualizacao)

--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/DispositivoPessoasController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/DispositivoPessoasController.cs
@@ -52,6 +52,7 @@ namespace GestaoGrupoMusicalAPI.Controllers
             var tokens = await context.DispositivoPessoa
                 .Where(d => d.Pessoa.IdGrupoMusical == idGrupo)
                 .Select(d => d.FcmToken)
+                .Distinct()
                 .ToListAsync();
 
             if (!tokens.Any())

--- a/Codigo/GestaoGrupoMusicalMobile/android/app/build.gradle.kts
+++ b/Codigo/GestaoGrupoMusicalMobile/android/app/build.gradle.kts
@@ -11,6 +11,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }

--- a/Codigo/GestaoGrupoMusicalMobile/android/app/src/main/AndroidManifest.xml
+++ b/Codigo/GestaoGrupoMusicalMobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:label="Batalá"

--- a/Codigo/GestaoGrupoMusicalMobile/android/gradle.properties
+++ b/Codigo/GestaoGrupoMusicalMobile/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/Codigo/GestaoGrupoMusicalMobile/lib/service/notificacao_service.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/service/notificacao_service.dart
@@ -1,74 +1,133 @@
+import 'dart:convert';
+
 import 'package:batala_mobile/config/session_manager.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import '../config/api_config.dart'; 
-import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:http/http.dart' as http;
+
+import '../config/api_config.dart';
 
 class NotificacaoService {
   final FirebaseMessaging _firebaseMessaging = FirebaseMessaging.instance;
 
+  static final FlutterLocalNotificationsPlugin _localNotifications =
+      FlutterLocalNotificationsPlugin();
+
+  static const AndroidNotificationChannel _notificationChannel =
+      AndroidNotificationChannel(
+    'notificacoes_gerais',
+    'Notificações gerais',
+    description: 'Notificações do Grupo Musical',
+    importance: Importance.max,
+  );
+
   Future<void> initNotifications() async {
-    NotificationSettings settings = await _firebaseMessaging.requestPermission(
+    await _initLocalNotifications();
+
+    final settings = await _firebaseMessaging.requestPermission(
       alert: true,
       badge: true,
       sound: true,
     );
 
     if (settings.authorizationStatus == AuthorizationStatus.authorized) {
-      print('Permissão concedida pelo usuário.');
-      
+      debugPrint('Permissão concedida pelo usuário.');
+
+      await _firebaseMessaging.setForegroundNotificationPresentationOptions(
+        alert: true,
+        badge: true,
+        sound: true,
+      );
+
       _configureForegroundNotifications();
     } else {
-      print('Permissão negada pelo usuário.');
+      debugPrint('Permissão negada pelo usuário.');
     }
   }
 
+  Future<void> _initLocalNotifications() async {
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(),
+    );
+
+    await _localNotifications.initialize(initializationSettings);
+
+    await _localNotifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(_notificationChannel);
+  }
 
   Future<void> registrarDispositivoNoBackend(int idPessoa) async {
     try {
-      String? token = await _firebaseMessaging.getToken();
+      final token = await _firebaseMessaging.getToken();
 
       if (token != null) {
-        print('FCM Token gerado com sucesso: $token');
+        debugPrint('FCM Token gerado com sucesso: $token');
         await _enviarTokenParaAPI(idPessoa, token);
       }
     } catch (e) {
-      print('Erro ao obter ou registrar o FCM Token: $e');
+      debugPrint('Erro ao obter ou registrar o FCM Token: $e');
     }
   }
 
   Future<void> _enviarTokenParaAPI(int idPessoa, String fcmToken) async {
-  final url = Uri.parse('${ApiConfig.baseUrl}/api/DispositivoPessoa/Registrar'); 
-  final jwtToken = await SessionManager.getToken();
+    final url =
+        Uri.parse('${ApiConfig.baseUrl}/api/DispositivoPessoa/Registrar');
+    final jwtToken = await SessionManager.getToken();
 
-  final response = await http.post(
-    url,
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': 'Bearer $jwtToken', 
-    },
-    // jsonEncode garante que o formato fique correto para o C#
-    body: jsonEncode({
-      "IdPessoa": idPessoa,        
-      "FcmToken": fcmToken,
-      "dataAtualizacao": DateTime.now().toIso8601String()
-    }),
-  );
+    final response = await http.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer $jwtToken',
+      },
+      body: jsonEncode({
+        'IdPessoa': idPessoa,
+        'FcmToken': fcmToken,
+        'dataAtualizacao': DateTime.now().toIso8601String(),
+      }),
+    );
 
-  if (response.statusCode == 200 || response.statusCode == 204) {
-    print('Sucesso total: Dispositivo registrado no banco!');
-  } else {
-    // Isso vai te mostrar exatamente o que o C# não gostou
-    print('Erro na API (${response.statusCode}): ${response.body}');
+    if (response.statusCode == 200 || response.statusCode == 204) {
+      debugPrint('Sucesso total: dispositivo registrado no banco!');
+    } else {
+      debugPrint('Erro na API (${response.statusCode}): ${response.body}');
+    }
   }
-}
+
   void _configureForegroundNotifications() {
-    FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-      print('Nova notificação recebida com o app aberto!');
-      if (message.notification != null) {
-        print('Título: ${message.notification!.title}');
-        print('Corpo: ${message.notification!.body}');
-  
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
+      debugPrint('Nova notificação recebida com o app aberto!');
+
+      final notification = message.notification;
+      if (notification == null) {
+        return;
+      }
+
+      debugPrint('Título: ${notification.title}');
+      debugPrint('Corpo: ${notification.body}');
+
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        final notificationId = message.messageId?.hashCode ??
+            DateTime.now().millisecondsSinceEpoch.remainder(2147483647);
+
+        await _localNotifications.show(
+          notificationId & 0x7fffffff,
+          notification.title ?? 'Batalá',
+          notification.body ?? '',
+          const NotificationDetails(
+            android: AndroidNotificationDetails(
+              'notificacoes_gerais',
+              'Notificações gerais',
+              channelDescription: 'Notificações do Grupo Musical',
+              importance: Importance.max,
+              priority: Priority.high,
+            ),
+          ),
+        );
       }
     });
   }

--- a/Codigo/GestaoGrupoMusicalMobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/Codigo/GestaoGrupoMusicalMobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import device_info_plus
 import firebase_core
 import firebase_messaging
+import flutter_local_notifications
 import shared_preferences_foundation
 import url_launcher_macos
 
@@ -15,6 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseMessagingPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseMessagingPlugin"))
+  FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/Codigo/GestaoGrupoMusicalMobile/pubspec.lock
+++ b/Codigo/GestaoGrupoMusicalMobile/pubspec.lock
@@ -105,6 +105,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.14"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -222,6 +230,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_local_notifications:
+    dependency: "direct main"
+    description:
+      name: flutter_local_notifications
+      sha256: ef41ae901e7529e52934feba19ed82827b11baa67336829564aeab3129460610
+      url: "https://pub.dev"
+    source: hosted
+    version: "18.0.1"
+  flutter_local_notifications_linux:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_linux
+      sha256: "8f685642876742c941b29c32030f6f4f6dacd0e4eaecb3efbb187d6a3812ca01"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.0"
+  flutter_local_notifications_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_local_notifications_platform_interface
+      sha256: "6c5b83c86bf819cdb177a9247a3722067dd8cc6313827ce7c77a4b238a26fd52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -364,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -561,10 +593,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.10.1"
   typed_data:
     dependency: transitive
     description:

--- a/Codigo/GestaoGrupoMusicalMobile/pubspec.yaml
+++ b/Codigo/GestaoGrupoMusicalMobile/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   device_info_plus: ^13.0.0
   firebase_core: ^4.10.0
   firebase_messaging: ^16.3.0
+  flutter_local_notifications: ^18.0.1
   jwt_decoder: ^2.0.1
 
 dev_dependencies:

--- a/Codigo/Service/DispositivoService.cs
+++ b/Codigo/Service/DispositivoService.cs
@@ -21,29 +21,39 @@ namespace Service
         {
             try
             {
-                var dispositivoExistente = await context.DispositivoPessoa
-                    .FirstOrDefaultAsync(d => d.IdPessoa == dto.IdPessoa);
+                var dispositivoExistente =
+                    await context.DispositivoPessoa
+                        .FirstOrDefaultAsync(
+                            d => d.FcmToken == dto.FcmToken);
 
                 if (dispositivoExistente != null)
                 {
-                    dispositivoExistente.FcmToken = dto.FcmToken;
+                    // O token já existe: transfere o aparelho
+                    // para a pessoa atualmente autenticada.
+                    dispositivoExistente.IdPessoa = dto.IdPessoa;
                     dispositivoExistente.DataAtualizacao = DateTime.Now;
-                    context.DispositivoPessoa.Update(dispositivoExistente);
                 }
                 else
                 {
-                    var novoDispositivo = new DispositivoPessoa
-                    {
-                        IdPessoa = dto.IdPessoa,
-                        FcmToken = dto.FcmToken,
-                        DataAtualizacao = DateTime.Now
-                    };
-                    await context.DispositivoPessoa.AddAsync(novoDispositivo);
+                    await context.DispositivoPessoa.AddAsync(
+                        new DispositivoPessoa
+                        {
+                            IdPessoa = dto.IdPessoa,
+                            FcmToken = dto.FcmToken,
+                            DataAtualizacao = DateTime.Now
+                        });
                 }
+
                 await context.SaveChangesAsync();
                 return true;
             }
-            catch { return false; }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"Erro ao registrar dispositivo: {ex.Message}");
+
+                return false;
+            }
         }
 
         public async Task EnviarNotificacaoParaGrupoAsync(int idGrupo, string titulo, string corpo)
@@ -51,6 +61,7 @@ namespace Service
             var tokens = await context.DispositivoPessoa
                 .Where(d => d.Pessoa.IdGrupoMusical == idGrupo)
                 .Select(d => d.FcmToken)
+                .Distinct()
                 .ToListAsync();
 
             foreach (var token in tokens)


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1> 
</div>

## Foi Solicitado

Corrigir o envio duplicado de notificações push para o mesmo aparelho.

Foi identificado que um mesmo token FCM poderia ficar associado a mais de uma pessoa na tabela `dispositivopessoa`. Durante o disparo para um grupo, o backend percorria todos os registros encontrados e enviava a mesma mensagem mais de uma vez para o token duplicado.

Também foi solicitado que a notificação aparecesse visualmente quando o aplicativo móvel estivesse aberto em primeiro plano.

## Foi Feito

- [x] Alterado o cadastro de dispositivos para localizar o aparelho pelo token FCM.
- [x] Implementada a transferência do token para a pessoa atualmente autenticada no aparelho.
- [x] Impedido que a troca de conta no mesmo celular crie registros duplicados.
- [x] Adicionado `Distinct()` na consulta de tokens do grupo antes do envio.
- [x] Adicionado `Distinct()` no endpoint de teste de notificações pelo Swagger.
- [x] Alterado o mapeamento do Entity Framework para limitar o token a 512 caracteres.
- [x] Adicionado índice único para `fcmToken` no mapeamento do Entity Framework.
- [x] Criado script SQL para remover duplicidades existentes e adicionar a restrição única no banco.
- [x] Adicionado o pacote `flutter_local_notifications` ao aplicativo móvel.
- [x] Criado um canal Android de alta prioridade para notificações.
- [x] Adicionada a permissão `POST_NOTIFICATIONS` para Android 13 ou superior.
- [x] Implementada a exibição de notificação local quando o aplicativo está em primeiro plano.

## Mudanças Que Não Estavam Previstas

- [x] Durante a correção das duplicidades, foi identificado que o aplicativo recebia a mensagem em primeiro plano, mas apenas registrava seu conteúdo no console.
- [x] Foi adicionada a exibição visual da notificação enquanto o aplicativo está aberto.
- [x] Foi incluída uma proteção adicional no banco para impedir tokens FCM duplicados, mesmo que outro fluxo tente inseri-los.
- [x] Foram adicionadas configurações de compatibilidade Android exigidas pelo novo plugin.

## Como Testar

### 1. Atualizar o banco de dados

Antes de executar a aplicação, faça backup do banco e execute o script:

```text
AnaliseProjeto/AtualizaTokenDispositivoUnico.sql
O script:
remove registros duplicados, preservando o mais recente;
altera fcmToken para VARCHAR(512);
cria uma restrição única para o token.
Confirme que não existem tokens duplicados:
SELECT
    fcmToken,
    COUNT(*) AS quantidade
FROM dispositivopessoa
GROUP BY fcmToken
HAVING COUNT(*) > 1;
A consulta deve retornar zero registros.
2. Preparar a API e o web
Os arquivos de credenciais não são versionados. Para testar localmente, disponibilize manualmente:
Codigo/GestaoGrupoMusicalAPI/firebase-admin.json
Codigo/GestaoGrupoMusicalWeb/firebase-admin.json
As credenciais devem pertencer ao mesmo projeto Firebase utilizado pelo aplicativo móvel.
Inicie a API:
dotnet run --project .\GestaoGrupoMusicalAPI\GestaoGrupoMusicalAPI.csproj --launch-profile http
Inicie a aplicação web:
dotnet run --project .\GestaoGrupoMusicalWeb\GestaoGrupoMusicalWeb.csproj --launch-profile GestaoGrupoMusicalWeb
3. Preparar o aplicativo móvel
Dentro do projeto mobile, execute:
flutter clean
flutter pub get
flutter run
Como foi adicionado um plugin nativo, é necessária uma recompilação completa. O Hot Reload sozinho não é suficiente.
No Android 13 ou superior, aceite a solicitação de permissão para notificações.
4. Testar o disparo pelo Swagger
Acesse:
http://localhost:5153/swagger
Execute:
POST /api/DispositivoPessoa/TestarDisparoParaGrupo/{idGrupo}
Informe somente o número do grupo e envie uma mensagem no corpo:
"Teste de notificação sem duplicidade"
Validar:

A notificação chega somente uma vez.

A notificação chega com o aplicativo em segundo plano.

A notificação aparece com o aplicativo aberto em primeiro plano.
5. Testar troca de conta
Entre no aplicativo com uma conta.
Consulte a tabela dispositivopessoa.
Saia e entre com outra conta no mesmo aparelho.
Consulte novamente a tabela.
Use:
SELECT
    dp.id,
    dp.idPessoa,
    p.nome,
    p.idGrupoMusical,
    dp.dataAtualizacao
FROM dispositivopessoa dp
INNER JOIN pessoa p
    ON p.id = dp.idPessoa;
Validar:

O mesmo token permanece em apenas uma linha.

O token passa a pertencer à pessoa atualmente autenticada.

A data de atualização é renovada.

O próximo disparo chega apenas uma vez.
6. Testar o fluxo real pelo web
Entre na aplicação web como administrador ou colaborador.
Crie um evento, ensaio, pagamento, informativo ou material de estudo.
Confirme que o cadastro foi concluído.
Verifique o recebimento no aplicativo móvel.
Validar:

O push chega ao grupo correto.

O push chega apenas uma vez.

O push aparece com o aplicativo aberto.

O push também chega com o aplicativo em segundo plano.

Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.