### PR TITLE
feat(mobile): adiciona justificativa de ausência para ensaios e eventos

### DIFF
--- a/Codigo/Core/DTO/EventoDTO.cs
+++ b/Codigo/Core/DTO/EventoDTO.cs
@@ -105,6 +105,7 @@ namespace Core.DTO
         public string? NomeInstrumento { get; set; }
         public string Status { get; set; } = null!;
         public InscricaoEventoPessoa StatusEnum { get; set; }
+        public string? Justificativa { get; set; }
     }
 
     public class SolicitarParticipacaoDTO

--- a/Codigo/Core/DTO/JustificativaAusenciaDTO.cs
+++ b/Codigo/Core/DTO/JustificativaAusenciaDTO.cs
@@ -1,0 +1,15 @@
+namespace Core.DTO
+{
+    public class JustificarAusenciaEnsaioDTO
+    {
+        public int IdEnsaio { get; set; }
+        public string? Justificativa { get; set; }
+    }
+
+    public class JustificarAusenciaEventoDTO
+    {
+        public int IdEvento { get; set; }
+        public string? Justificativa { get; set; }
+    }
+}
+

--- a/Codigo/Core/DTO/JustificativaAusenciaDTO.cs
+++ b/Codigo/Core/DTO/JustificativaAusenciaDTO.cs
@@ -1,15 +1,17 @@
-namespace Core.DTO
+using System.ComponentModel.DataAnnotations;
+
+namespace Core.DTO;
+
+/// <summary>
+/// Dados enviados pelo associado ao justificar a ausência em um ensaio ou evento.
+/// </summary>
+public class JustificativaAusenciaDTO
 {
-    public class JustificarAusenciaEnsaioDTO
-    {
-        public int IdEnsaio { get; set; }
-        public string? Justificativa { get; set; }
-    }
+    public int IdEnsaio { get; set; }
 
-    public class JustificarAusenciaEventoDTO
-    {
-        public int IdEvento { get; set; }
-        public string? Justificativa { get; set; }
-    }
+    public int IdEvento { get; set; }
+
+    [Required(ErrorMessage = "A justificativa é obrigatória.")]
+    [StringLength(200, ErrorMessage = "A justificativa deve ter no máximo 200 caracteres.")]
+    public string? Justificativa { get; set; }
 }
-

--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/EnsaioController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/EnsaioController.cs
@@ -1,8 +1,11 @@
 ﻿using AutoMapper;
+using Core;
 using Core.DTO;
 using Core.Service;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
+
 
 namespace GestaoGrupoMusicalAPI.Controllers
 {
@@ -10,6 +13,7 @@ namespace GestaoGrupoMusicalAPI.Controllers
     [ApiController]
     public class EnsaioController : ControllerBase
     {
+
         private readonly IEnsaioService ensaioService;
         private readonly IMapper mapper;
 
@@ -22,12 +26,14 @@ namespace GestaoGrupoMusicalAPI.Controllers
         // GET: api/<EnsaioController>
         [HttpGet]
         public async Task<ActionResult> GetAsync()
-        {
-            var listaEnsaios = await ensaioService.GetAllIndexDTO(1);
-            if (listaEnsaios == null) return NotFound();
+        {   
 
+            var listaEnsaios = await ensaioService.GetAllIndexDTO(1);
+            if(listaEnsaios == null) return NotFound();
+            
             var listaDto = mapper.Map<IEnumerable<EnsaioIndexDTO>>(listaEnsaios);
             return Ok(listaDto);
+           
         }
 
         // GET api/<EnsaioController>/5
@@ -43,52 +49,62 @@ namespace GestaoGrupoMusicalAPI.Controllers
             var response = new EventosEnsaiosAssociadoDTO
             {
                 Ensaios = new List<EnsaioAssociadoDTO> { ensaioItem },
-                Eventos = new List<EventoAssociadoDTO>()
+                Eventos = new List<EventoAssociadoDTO>() // Lista vazia ou vinda de outro serviço
             };
 
             return Ok(response);
         }
 
-        // POST: api/Ensaio/JustificarAusencia
-        [HttpPost("JustificarAusencia")]
-        public async Task<ActionResult> JustificarAusencia([FromBody] JustificarAusenciaEnsaioDTO dto)
-        {
-            var claimId = User.FindFirst("Id")?.Value;
-            int.TryParse(claimId, out int idPessoa);
-
-            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
-
-            var resultado = await ensaioService.RegistrarJustificativaAsync(dto.IdEnsaio, idPessoa, dto.Justificativa);
-
-            if (resultado == HttpStatusCode.OK)
-            {
-                return Ok(new { mensagem = "Justificativa enviada com sucesso!" });
-            }
-
-            return BadRequest(new { mensagem = "Não foi possível registrar a justificativa." });
-        }
-
-        // GET: api/Ensaio/DetalhesSolicitacao/{idEnsaio}
+        [Authorize]
         [HttpGet("DetalhesSolicitacao/{idEnsaio}")]
         public async Task<ActionResult> GetDetalhesSolicitacao(int idEnsaio)
         {
-            var claimId = User.FindFirst("Id")?.Value;
-            int.TryParse(claimId, out int idPessoa);
+            var idPessoa = ObterIdPessoaLogada();
+            if (idPessoa <= 0)
+                return Unauthorized(new { mensagem = "Não foi possível identificar o associado autenticado." });
 
-            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
-
-            var ensaioPessoa = await ensaioService.GetEnsaioPessoaAsync(idEnsaio, idPessoa);
-
-            if (ensaioPessoa == null) return NotFound(new { mensagem = "Registro não encontrado." });
+            var frequencia = await ensaioService.GetEnsaioPessoaAsync(idEnsaio, idPessoa);
+            if (frequencia == null)
+                return NotFound(new { mensagem = "Você não está vinculado a este ensaio." });
 
             return Ok(new
             {
-                idEnsaio = ensaioPessoa.IdEnsaio,
-                idPessoa = ensaioPessoa.IdPessoa,
-                presente = ensaioPessoa.Presente,
-                justificativa = ensaioPessoa.JustificativaFalta,
-                justificativaAceita = ensaioPessoa.JustificativaAceita
+                idEnsaio,
+                justificativa = frequencia.JustificativaFalta,
+                presente = frequencia.Presente == 1,
+                justificativaAceita = frequencia.JustificativaAceita == 1
             });
         }
+
+        [Authorize]
+        [HttpPost("JustificarAusencia")]
+        public async Task<ActionResult> JustificarAusencia([FromBody] JustificativaAusenciaDTO dto)
+        {
+            if (!ModelState.IsValid || dto.IdEnsaio <= 0)
+                return BadRequest(new { mensagem = "Informe um ensaio e uma justificativa válida." });
+
+            var idPessoa = ObterIdPessoaLogada();
+            if (idPessoa <= 0)
+                return Unauthorized(new { mensagem = "Não foi possível identificar o associado autenticado." });
+
+            var resultado = await ensaioService.RegistrarJustificativaAsync(
+                dto.IdEnsaio,
+                idPessoa,
+                dto.Justificativa!.Trim());
+
+            return resultado switch
+            {
+                HttpStatusCode.OK => Ok(new { mensagem = "Justificativa registrada com sucesso." }),
+                HttpStatusCode.NotFound => NotFound(new { mensagem = "Você não está vinculado a este ensaio." }),
+                _ => StatusCode(StatusCodes.Status500InternalServerError,
+                    new { mensagem = "Não foi possível registrar a justificativa." })
+            };
+        }
+
+        private int ObterIdPessoaLogada()
+        {
+            return int.TryParse(User.FindFirst("IdPessoa")?.Value, out var idPessoa) ? idPessoa : 0;
+        }
+       
     }
 }

--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/EnsaioController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/EnsaioController.cs
@@ -1,9 +1,8 @@
 ﻿using AutoMapper;
-using Core;
 using Core.DTO;
 using Core.Service;
 using Microsoft.AspNetCore.Mvc;
-
+using System.Net;
 
 namespace GestaoGrupoMusicalAPI.Controllers
 {
@@ -11,7 +10,6 @@ namespace GestaoGrupoMusicalAPI.Controllers
     [ApiController]
     public class EnsaioController : ControllerBase
     {
-
         private readonly IEnsaioService ensaioService;
         private readonly IMapper mapper;
 
@@ -24,14 +22,12 @@ namespace GestaoGrupoMusicalAPI.Controllers
         // GET: api/<EnsaioController>
         [HttpGet]
         public async Task<ActionResult> GetAsync()
-        {   
-
+        {
             var listaEnsaios = await ensaioService.GetAllIndexDTO(1);
-            if(listaEnsaios == null) return NotFound();
-            
+            if (listaEnsaios == null) return NotFound();
+
             var listaDto = mapper.Map<IEnumerable<EnsaioIndexDTO>>(listaEnsaios);
             return Ok(listaDto);
-           
         }
 
         // GET api/<EnsaioController>/5
@@ -47,11 +43,52 @@ namespace GestaoGrupoMusicalAPI.Controllers
             var response = new EventosEnsaiosAssociadoDTO
             {
                 Ensaios = new List<EnsaioAssociadoDTO> { ensaioItem },
-                Eventos = new List<EventoAssociadoDTO>() // Lista vazia ou vinda de outro serviço
+                Eventos = new List<EventoAssociadoDTO>()
             };
 
             return Ok(response);
         }
-       
+
+        // POST: api/Ensaio/JustificarAusencia
+        [HttpPost("JustificarAusencia")]
+        public async Task<ActionResult> JustificarAusencia([FromBody] JustificarAusenciaEnsaioDTO dto)
+        {
+            var claimId = User.FindFirst("Id")?.Value;
+            int.TryParse(claimId, out int idPessoa);
+
+            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
+
+            var resultado = await ensaioService.RegistrarJustificativaAsync(dto.IdEnsaio, idPessoa, dto.Justificativa);
+
+            if (resultado == HttpStatusCode.OK)
+            {
+                return Ok(new { mensagem = "Justificativa enviada com sucesso!" });
+            }
+
+            return BadRequest(new { mensagem = "Não foi possível registrar a justificativa." });
+        }
+
+        // GET: api/Ensaio/DetalhesSolicitacao/{idEnsaio}
+        [HttpGet("DetalhesSolicitacao/{idEnsaio}")]
+        public async Task<ActionResult> GetDetalhesSolicitacao(int idEnsaio)
+        {
+            var claimId = User.FindFirst("Id")?.Value;
+            int.TryParse(claimId, out int idPessoa);
+
+            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
+
+            var ensaioPessoa = await ensaioService.GetEnsaioPessoaAsync(idEnsaio, idPessoa);
+
+            if (ensaioPessoa == null) return NotFound(new { mensagem = "Registro não encontrado." });
+
+            return Ok(new
+            {
+                idEnsaio = ensaioPessoa.IdEnsaio,
+                idPessoa = ensaioPessoa.IdPessoa,
+                presente = ensaioPessoa.Presente,
+                justificativa = ensaioPessoa.JustificativaFalta,
+                justificativaAceita = ensaioPessoa.JustificativaAceita
+            });
+        }
     }
 }

--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/EventoController.cs
@@ -32,15 +32,11 @@ namespace GestaoGrupoMusicalAPI.Controllers
 
         // GET: api/Evento/Detalhes/5
         // Retorna tudo o que a tela de "Aceitar" do Mobile precisa
-        [AllowAnonymous]
+        [Authorize]
         [HttpGet("Detalhes/{id}")]
         public async Task<ActionResult> GetDetalhesSolicitacao(int id)
         {
-            // 1. Pega o valor do Token
-            var claimId = User.FindFirst("Id")?.Value;
-
-            // 2. Tenta converter. Se for GUID, idPessoa será 0
-            int.TryParse(claimId, out int idPessoa);
+            var idPessoa = ObterIdPessoaLogada();
 
             // 3. Busca o evento
             var evento = eventoService.Get(id);
@@ -48,7 +44,6 @@ namespace GestaoGrupoMusicalAPI.Controllers
 
             var instrumentos = await eventoService.GetInstrumentosDisponiveisAsync(id);
 
-            // 4. Busca a inscrição apenas se o ID for válido (> 0)
             var minhaInscricao = idPessoa > 0
                 ? await eventoService.GetSolicitacaoAssociado(id, idPessoa)
                 : null;
@@ -62,24 +57,43 @@ namespace GestaoGrupoMusicalAPI.Controllers
                 repertorio = evento.Repertorio,
                 local = evento.Local,
                 instrumentosDisponiveis = instrumentos,
-                inscricao = minhaInscricao
+                inscricao = minhaInscricao,
+                minhaInscricao
             });
         }
 
+        [Authorize]
+        [HttpPost("JustificarAusencia")]
+        public async Task<ActionResult> JustificarAusencia([FromBody] JustificativaAusenciaDTO dto)
+        {
+            if (!ModelState.IsValid || dto.IdEvento <= 0)
+                return BadRequest(new { mensagem = "Informe um evento e uma justificativa válida." });
+
+            var idPessoa = ObterIdPessoaLogada();
+            if (idPessoa <= 0)
+                return Unauthorized(new { mensagem = "Não foi possível identificar o associado autenticado." });
+
+            var resultado = await eventoService.RegistrarJustificativaAsync(
+                dto.IdEvento,
+                idPessoa,
+                dto.Justificativa!.Trim());
+
+            return resultado switch
+            {
+                HttpStatusCode.OK => Ok(new { mensagem = "Justificativa registrada com sucesso." }),
+                HttpStatusCode.NotFound => NotFound(new { mensagem = "Você não está vinculado a este evento." }),
+                HttpStatusCode.BadRequest => BadRequest(new { mensagem = "A justificativa só pode ser enviada após a aprovação da participação." }),
+                _ => StatusCode(StatusCodes.Status500InternalServerError,
+                    new { mensagem = "Não foi possível registrar a justificativa." })
+            };
+        }
+
         // POST: api/Evento/ResponderPresenca
+        [Authorize]
         [HttpPost("ResponderPresenca")]
         public async Task<ActionResult> ResponderPresenca([FromBody] SolicitarParticipacaoDTO dto)
         {
-            // 1. Pega o valor do Token (que está vindo como GUID)
-            var claimId = User.FindFirst("Id")?.Value;
-
-            // 2. Tenta converter. Se falhar, tenta usar a claim "IdPessoa" (caso você tenha configurado)
-            if (!int.TryParse(claimId, out int idPessoa))
-            {
-                // Fallback: se o "Id" for GUID, talvez você tenha o ID numérico em outra claim
-                var claimIdPessoa = User.FindFirst("IdPessoa")?.Value;
-                int.TryParse(claimIdPessoa, out idPessoa);
-            }
+            var idPessoa = ObterIdPessoaLogada();
 
             // 3. Se ainda assim for 0, o sistema não pode prosseguir
             if (idPessoa <= 0)
@@ -108,11 +122,11 @@ namespace GestaoGrupoMusicalAPI.Controllers
         }
 
         // POST: api/Evento/CancelarPresenca
+        [Authorize]
         [HttpPost("CancelarPresenca/{idEvento}")]
         public async Task<ActionResult> CancelarPresenca(int idEvento)
         {
-            var claimId = User.FindFirst("Id")?.Value;
-            int.TryParse(claimId, out int idPessoa);
+            var idPessoa = ObterIdPessoaLogada();
 
             if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
 
@@ -124,47 +138,9 @@ namespace GestaoGrupoMusicalAPI.Controllers
             return BadRequest(new { mensagem = "Não foi possível cancelar. Verifique se a solicitação já foi aprovada." });
         }
 
-        // POST: api/Evento/JustificarAusencia
-        [HttpPost("JustificarAusencia")]
-        public async Task<ActionResult> JustificarAusencia([FromBody] JustificarAusenciaEventoDTO dto)
+        private int ObterIdPessoaLogada()
         {
-            var claimId = User.FindFirst("Id")?.Value;
-            if (!int.TryParse(claimId, out int idPessoa))
-            {
-                var claimIdPessoa = User.FindFirst("IdPessoa")?.Value;
-                int.TryParse(claimIdPessoa, out idPessoa);
-            }
-
-            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
-
-            var resultado = await eventoService.RegistrarJustificativaAsync(dto.IdEvento, idPessoa, dto.Justificativa);
-
-            if (resultado == HttpStatusCode.OK)
-            {
-                return Ok(new { mensagem = "Justificativa enviada com sucesso!" });
-            }
-
-            return BadRequest(new { mensagem = "Não foi possível registrar a justificativa." });
-        }
-
-        // GET: api/Evento/MinhaInscricao/{idEvento}
-        [HttpGet("MinhaInscricao/{idEvento}")]
-        public async Task<ActionResult> GetMinhaInscricao(int idEvento)
-        {
-            var claimId = User.FindFirst("Id")?.Value;
-            if (!int.TryParse(claimId, out int idPessoa))
-            {
-                var claimIdPessoa = User.FindFirst("IdPessoa")?.Value;
-                int.TryParse(claimIdPessoa, out idPessoa);
-            }
-
-            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
-
-            var minhaInscricao = await eventoService.GetSolicitacaoAssociado(idEvento, idPessoa);
-
-            if (minhaInscricao == null) return NotFound(new { mensagem = "Inscrição não encontrada." });
-
-            return Ok(minhaInscricao);
+            return int.TryParse(User.FindFirst("IdPessoa")?.Value, out var idPessoa) ? idPessoa : 0;
         }
     }
 }

--- a/Codigo/GestaoGrupoMusicalAPI/Controllers/EventoController.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Controllers/EventoController.cs
@@ -123,5 +123,48 @@ namespace GestaoGrupoMusicalAPI.Controllers
 
             return BadRequest(new { mensagem = "Não foi possível cancelar. Verifique se a solicitação já foi aprovada." });
         }
+
+        // POST: api/Evento/JustificarAusencia
+        [HttpPost("JustificarAusencia")]
+        public async Task<ActionResult> JustificarAusencia([FromBody] JustificarAusenciaEventoDTO dto)
+        {
+            var claimId = User.FindFirst("Id")?.Value;
+            if (!int.TryParse(claimId, out int idPessoa))
+            {
+                var claimIdPessoa = User.FindFirst("IdPessoa")?.Value;
+                int.TryParse(claimIdPessoa, out idPessoa);
+            }
+
+            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
+
+            var resultado = await eventoService.RegistrarJustificativaAsync(dto.IdEvento, idPessoa, dto.Justificativa);
+
+            if (resultado == HttpStatusCode.OK)
+            {
+                return Ok(new { mensagem = "Justificativa enviada com sucesso!" });
+            }
+
+            return BadRequest(new { mensagem = "Não foi possível registrar a justificativa." });
+        }
+
+        // GET: api/Evento/MinhaInscricao/{idEvento}
+        [HttpGet("MinhaInscricao/{idEvento}")]
+        public async Task<ActionResult> GetMinhaInscricao(int idEvento)
+        {
+            var claimId = User.FindFirst("Id")?.Value;
+            if (!int.TryParse(claimId, out int idPessoa))
+            {
+                var claimIdPessoa = User.FindFirst("IdPessoa")?.Value;
+                int.TryParse(claimIdPessoa, out idPessoa);
+            }
+
+            if (idPessoa <= 0) return BadRequest(new { mensagem = "Usuário inválido." });
+
+            var minhaInscricao = await eventoService.GetSolicitacaoAssociado(idEvento, idPessoa);
+
+            if (minhaInscricao == null) return NotFound(new { mensagem = "Inscrição não encontrada." });
+
+            return Ok(minhaInscricao);
+        }
     }
 }

--- a/Codigo/GestaoGrupoMusicalAPI/Program.cs
+++ b/Codigo/GestaoGrupoMusicalAPI/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models; // Necessário para configurar o Swagger Bearer
 using Service;
 using System.Text;
 
@@ -91,7 +92,35 @@ builder.Services.AddCors(options => {
 });
 
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "GestaoGrupoMusicalAPI", Version = "v1" });
+
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Description = "Insira o token JWT no formato: Bearer {seu_token}",
+        Name = "Authorization",
+        In = ParameterLocation.Header,
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = "Bearer"
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
 
 var app = builder.Build();
 

--- a/Codigo/GestaoGrupoMusicalMobile/lib/screens/home_view.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/screens/home_view.dart
@@ -7,7 +7,6 @@ import '../model/evento_model.dart';
 import '../service/evento_service.dart';
 import '../service/ensaio_service.dart';
 
-
 class HomeView extends StatefulWidget {
   const HomeView({super.key});
 
@@ -21,16 +20,15 @@ class _HomeViewState extends State<HomeView> {
   late Future<List<EventoModel>> _futureEventos;
   late Future<List<EnsaioModel>> _futureEnsaios;
 
-  // Controladores de scroll e limites de paginação
   final ScrollController _eventoScrollController = ScrollController();
   final ScrollController _ensaioScrollController = ScrollController();
-  
+
   int _eventosLimit = 3;
   int _ensaiosLimit = 3;
   final int _incrementoPaginacao = 3;
 
-  // NOVO: Cache local em memória para os detalhes dos eventos
   final Map<int, Map<String, dynamic>> _detalhesCache = {};
+  final Map<int, Future<Map<String, dynamic>?>> _estadoEventos = {};
 
   @override
   void initState() {
@@ -39,7 +37,6 @@ class _HomeViewState extends State<HomeView> {
     _ensaioService = EnsaioService();
     _carregarDados();
 
-    // Listeners para ativar a paginação ao "esticar" o final da lista
     _eventoScrollController.addListener(_onEventoScroll);
     _ensaioScrollController.addListener(_onEnsaioScroll);
   }
@@ -60,17 +57,18 @@ class _HomeViewState extends State<HomeView> {
     await _eventoService.limparCacheListagem();
     await _ensaioService.limparCacheListagem();
 
-    // 2. ATUALIZA A TELA E RECARREGA OS DADOS
     setState(() {
       _eventosLimit = 3;
       _ensaiosLimit = 3;
-      _detalhesCache.clear(); // Mantém a limpeza do cache de memória dos detalhes
-      _carregarDados(); // Agora sim, os services serão forçados a fazer o GET na API
+      _detalhesCache.clear();
+      _estadoEventos.clear();
+      _carregarDados();
     });
   }
 
   void _onEventoScroll() {
-    if (_eventoScrollController.offset >= _eventoScrollController.position.maxScrollExtent) {
+    if (_eventoScrollController.offset >=
+        _eventoScrollController.position.maxScrollExtent) {
       setState(() {
         _eventosLimit += _incrementoPaginacao;
       });
@@ -78,11 +76,109 @@ class _HomeViewState extends State<HomeView> {
   }
 
   void _onEnsaioScroll() {
-    if (_ensaioScrollController.offset >= _ensaioScrollController.position.maxScrollExtent) {
+    if (_ensaioScrollController.offset >=
+        _ensaioScrollController.position.maxScrollExtent) {
       setState(() {
         _ensaiosLimit += _incrementoPaginacao;
       });
     }
+  }
+
+  // Método unificado para abrir o modal de justificativa (GET + POST)
+  void _abrirModalJustificativa({
+    required int id,
+    required bool isEnsaio,
+  }) async {
+    final TextEditingController justificativaController =
+        TextEditingController();
+
+    _showLoading();
+    try {
+      if (isEnsaio) {
+        final dados = await _ensaioService.getMinhaFrequencia(id);
+        if (dados != null) {
+          justificativaController.text = dados['justificativa'] ?? '';
+        }
+      } else {
+        final dados = await _eventoService.getDetalhesEvento(id);
+        if (dados != null) {
+          final minhaInscricao = dados['minhaInscricao'] ?? dados['inscricao'];
+          if (minhaInscricao != null) {
+            justificativaController.text = minhaInscricao['justificativa'] ??
+                minhaInscricao['Justificativa'] ??
+                '';
+          }
+        }
+      }
+    } catch (_) {}
+    if (mounted) Navigator.of(context, rootNavigator: true).pop();
+
+    if (!mounted) return;
+
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(isEnsaio
+            ? 'Justificar Ausência (Ensaio)'
+            : 'Justificar Ausência (Evento)'),
+        content: TextField(
+          controller: justificativaController,
+          maxLines: 4,
+          decoration: const InputDecoration(
+            hintText: 'Escreva o motivo da sua ausência...',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancelar'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              final justificativa = justificativaController.text.trim();
+              if (justificativa.isEmpty) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                      content: Text('Informe o motivo da ausência.')),
+                );
+                return;
+              }
+
+            
+
+            _showLoading();
+              
+              final mensagemErro = isEnsaio 
+                  ? await _ensaioService.justificarAusencia(id, justificativa)
+                  : await _eventoService.justificarAusencia(id, justificativa);
+
+              final sucesso = mensagemErro == null;
+
+              if (!mounted) return;
+              Navigator.of(context, rootNavigator: true).pop(); // fecha loading
+              Navigator.of(context, rootNavigator: true).pop(); // fecha dialog
+
+              if (sucesso && !isEnsaio) {
+                await _atualizarEstadoEvento(id);
+              }
+
+              final textoMensagem = sucesso
+                  ? 'Justificativa enviada com sucesso!'
+                  : mensagemErro;
+
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(textoMensagem),
+                  backgroundColor: sucesso ? Colors.green : Colors.red,
+                ),
+              );
+            },
+            child: const Text('Enviar'),
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -115,18 +211,18 @@ class _HomeViewState extends State<HomeView> {
     );
   }
 
-  Widget _buildSection<T>(
-      String title, 
-      Future<List<T>> future, 
-      ScrollController controller, 
-      int limit, 
-      Widget Function(T) builder) {
+  Widget _buildSection<T>(String title, Future<List<T>> future,
+      ScrollController controller, int limit, Widget Function(T) builder) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Padding(
           padding: const EdgeInsets.fromLTRB(20, 16, 20, 8),
-          child: Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.black87)),
+          child: Text(title,
+              style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87)),
         ),
         Expanded(
           child: FutureBuilder<List<T>>(
@@ -135,17 +231,23 @@ class _HomeViewState extends State<HomeView> {
               if (snapshot.connectionState == ConnectionState.waiting) {
                 return const Center(child: CircularProgressIndicator());
               }
-              if (snapshot.hasError) return const Center(child: Text("Erro ao carregar"));
-              
+              if (snapshot.hasError) {
+                return const Center(child: Text("Erro ao carregar"));
+              }
+
               final list = snapshot.data ?? [];
-              if (list.isEmpty) return const Center(child: Text("Nada agendado."));
+              if (list.isEmpty) {
+                return const Center(child: Text("Nada agendado."));
+              }
 
               final int itemCount = math.min(list.length, limit);
 
               return ListView.builder(
                 controller: controller,
-                physics: const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics()), 
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                physics: const BouncingScrollPhysics(
+                    parent: AlwaysScrollableScrollPhysics()),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
                 itemCount: itemCount,
                 itemBuilder: (context, index) {
                   return builder(list[index]);
@@ -158,37 +260,113 @@ class _HomeViewState extends State<HomeView> {
     );
   }
 
-  Widget _buildEventCard(BuildContext context, EventoModel item, EventoService service) {
+  Widget _buildEventCard(
+      BuildContext context, EventoModel item, EventoService service) {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () => _abrirDetalhes(item.id, service),
       child: _baseCard(
         title: item.local,
         date: item.dataInicio,
-        actionWidget: EventToggleButton(
-          isAccepted: false,
-          onPressed: () => _abrirSelecaoInstrumento(item.id, service),
+        actionWidget: FutureBuilder<Map<String, dynamic>?>(
+          future: _obterEstadoEvento(item.id),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              );
+            }
+
+            final inscricao =
+                snapshot.data?['minhaInscricao'] ?? snapshot.data?['inscricao'];
+            final status =
+                (inscricao?['status'] as String? ?? '').toUpperCase();
+
+            if (status == 'DEFERIDO') {
+              return IconButton(
+                icon: const Icon(Icons.note_alt_outlined,
+                    color: Colors.orange, size: 22),
+                tooltip: 'Justificar ausência',
+                onPressed: () =>
+                    _abrirModalJustificativa(id: item.id, isEnsaio: false),
+              );
+            }
+
+            if (status == 'INSCRITO') {
+              return const _StatusParticipacao(
+                texto: 'AGUARDANDO',
+                icone: Icons.hourglass_top,
+                cor: Colors.orange,
+              );
+            }
+
+            if (status == 'INDEFERIDO') {
+              return const _StatusParticipacao(
+                texto: 'NÃO APROVADO',
+                icone: Icons.cancel_outlined,
+                cor: Colors.red,
+              );
+            }
+
+            return EventToggleButton(
+              isAccepted: false,
+              onPressed: () => _abrirSelecaoInstrumento(item.id, service),
+            );
+          },
         ),
       ),
     );
   }
 
+  Future<Map<String, dynamic>?> _obterEstadoEvento(int idEvento) {
+    return _estadoEventos.putIfAbsent(
+      idEvento,
+      () => _eventoService.getDetalhesEvento(idEvento),
+    );
+  }
+
+  Future<void> _atualizarEstadoEvento(int idEvento) async {
+    await _eventoService.limparCacheListagem();
+    if (!mounted) return;
+
+    setState(() {
+      _detalhesCache.remove(idEvento);
+      _estadoEventos.remove(idEvento);
+    });
+  }
+
+  Widget _buildEnsaioCard(EnsaioModel item) {
+    return _baseCard(
+      title: item.local,
+      date: item.dataHora,
+      subtitle: "Ensaio Geral",
+      actionWidget: IconButton(
+        icon:
+            const Icon(Icons.note_alt_outlined, color: Colors.orange, size: 22),
+        tooltip: 'Justificar Ausência',
+        onPressed: () => _abrirModalJustificativa(id: item.id, isEnsaio: true),
+      ),
+    );
+  }
+
   Future<void> _abrirDetalhes(int id, EventoService service) async {
-    // 1. Verifica se os dados já estão no cache em memória
     if (_detalhesCache.containsKey(id)) {
       _mostrarModalInformativo(_detalhesCache[id]!);
       return;
     }
 
-    // 2. Se não estiver no cache, chama a API
     _showLoading();
     try {
-      final data = await service.getDetalhesEvento(id).timeout(const Duration(seconds: 8));
+      final data = await service
+          .getDetalhesEvento(id)
+          .timeout(const Duration(seconds: 8));
       if (!mounted) return;
       Navigator.of(context, rootNavigator: true).pop();
 
       if (data != null) {
-        _detalhesCache[id] = data; // 3. Salva a resposta no cache para a próxima vez
+        _detalhesCache[id] = data;
         _mostrarModalInformativo(data);
       }
     } catch (e) {
@@ -200,20 +378,39 @@ class _HomeViewState extends State<HomeView> {
     final df = DateFormat('dd/MM/yyyy HH:mm');
     showModalBottomSheet(
       context: context,
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.vertical(top: Radius.circular(25))),
+      shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(top: Radius.circular(25))),
       builder: (context) => Padding(
         padding: const EdgeInsets.all(24.0),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Center(child: Container(width: 40, height: 4, decoration: BoxDecoration(color: Colors.grey[300], borderRadius: BorderRadius.circular(10)))),
+            Center(
+                child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                        color: Colors.grey[300],
+                        borderRadius: BorderRadius.circular(10)))),
             const SizedBox(height: 20),
-            Text(data['repertorio'] ?? "Sem Repertório", style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
+            Text(data['repertorio'] ?? "Sem Repertório",
+                style:
+                    const TextStyle(fontSize: 22, fontWeight: FontWeight.bold)),
             const SizedBox(height: 15),
             _infoRow(Icons.location_on, "Local", data['local']),
-            _infoRow(Icons.calendar_today, "Início", data['dataHoraInicio'] != null ? df.format(DateTime.parse(data['dataHoraInicio'])) : "N/A"),
-            _infoRow(Icons.event_busy, "Fim", data['dataHoraFim'] != null ? df.format(DateTime.parse(data['dataHoraFim'])) : "N/A"),
+            _infoRow(
+                Icons.calendar_today,
+                "Início",
+                data['dataHoraInicio'] != null
+                    ? df.format(DateTime.parse(data['dataHoraInicio']))
+                    : "N/A"),
+            _infoRow(
+                Icons.event_busy,
+                "Fim",
+                data['dataHoraFim'] != null
+                    ? df.format(DateTime.parse(data['dataHoraFim']))
+                    : "N/A"),
             const SizedBox(height: 20),
           ],
         ),
@@ -222,13 +419,11 @@ class _HomeViewState extends State<HomeView> {
   }
 
   Future<void> _abrirSelecaoInstrumento(int id, EventoService service) async {
-    // 1. Verifica se os dados já estão no cache em memória
     if (_detalhesCache.containsKey(id)) {
       _mostrarModalInscricao(_detalhesCache[id]!, service);
       return;
     }
 
-    // 2. Se não estiver no cache, chama a API
     _showLoading();
     try {
       final data = await service.getDetalhesEvento(id);
@@ -236,7 +431,7 @@ class _HomeViewState extends State<HomeView> {
       Navigator.of(context, rootNavigator: true).pop();
 
       if (data != null) {
-        _detalhesCache[id] = data; // 3. Salva a resposta no cache
+        _detalhesCache[id] = data;
         _mostrarModalInscricao(data, service);
       }
     } catch (e) {
@@ -244,7 +439,8 @@ class _HomeViewState extends State<HomeView> {
     }
   }
 
-  void _mostrarModalInscricao(Map<String, dynamic> data, EventoService service) {
+  void _mostrarModalInscricao(
+      Map<String, dynamic> data, EventoService service) {
     final List instrumentos = data['instrumentosDisponiveis'] ?? [];
 
     showModalBottomSheet(
@@ -270,7 +466,8 @@ class _HomeViewState extends State<HomeView> {
                 child: Center(
                   child: Column(
                     children: [
-                      Icon(Icons.info_outline, size: 50, color: Colors.grey[400]),
+                      Icon(Icons.info_outline,
+                          size: 50, color: Colors.grey[400]),
                       const SizedBox(height: 16),
                       Text(
                         "Ops! Não há instrumentos disponíveis para este evento no momento.",
@@ -290,13 +487,16 @@ class _HomeViewState extends State<HomeView> {
               const Text("Selecione o instrumento que você irá tocar:"),
               const Divider(height: 30),
               ...instrumentos.map((inst) => ListTile(
-                    leading: const Icon(Icons.music_note, color: AppColors.primary),
+                    leading:
+                        const Icon(Icons.music_note, color: AppColors.primary),
                     title: Text(inst['nomeInstrumento']),
-                    subtitle: Text("${inst['vagasDisponiveis']} vagas restantes"),
+                    subtitle:
+                        Text("${inst['vagasDisponiveis']} vagas restantes"),
                     trailing: const Icon(Icons.chevron_right),
                     onTap: () async {
                       Navigator.pop(context);
-                      _processarInscricao(data['id'], inst['idInstrumento'], inst['nomeInstrumento'], service);
+                      _processarInscricao(data['id'], inst['idInstrumento'],
+                          inst['nomeInstrumento'], service);
                     },
                   )),
             ],
@@ -307,21 +507,25 @@ class _HomeViewState extends State<HomeView> {
     );
   }
 
-  Future<void> _processarInscricao(int eventoId, int instId, String nomeInst, EventoService service) async {
+  Future<void> _processarInscricao(
+      int eventoId, int instId, String nomeInst, EventoService service) async {
     _showLoading();
 
     try {
       final erro = await service.solicitarParticipacao(eventoId, instId);
-      
+
       if (!mounted) return;
       Navigator.of(context, rootNavigator: true).pop();
 
       if (erro == null) {
+        await _atualizarEstadoEvento(eventoId);
         showDialog(
           context: context,
           builder: (context) => AlertDialog(
-            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
-            title: const Icon(Icons.check_circle, color: Colors.green, size: 60),
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+            title:
+                const Icon(Icons.check_circle, color: Colors.green, size: 60),
             content: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
@@ -339,7 +543,8 @@ class _HomeViewState extends State<HomeView> {
             actions: [
               TextButton(
                 onPressed: () => Navigator.pop(context),
-                child: const Text("OK", style: TextStyle(fontWeight: FontWeight.bold)),
+                child: const Text("OK",
+                    style: TextStyle(fontWeight: FontWeight.bold)),
               ),
             ],
           ),
@@ -352,7 +557,9 @@ class _HomeViewState extends State<HomeView> {
     } catch (e) {
       if (mounted) Navigator.of(context, rootNavigator: true).pop();
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text("Erro ao enviar solicitação."), backgroundColor: Colors.red),
+        const SnackBar(
+            content: Text("Erro ao enviar solicitação."),
+            backgroundColor: Colors.red),
       );
     }
   }
@@ -370,21 +577,25 @@ class _HomeViewState extends State<HomeView> {
   }
 
   void _showLoading() {
-    showDialog(context: context, barrierDismissible: false, builder: (_) => const Center(child: CircularProgressIndicator()));
+    showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => const Center(child: CircularProgressIndicator()));
   }
 
   void _handleError(Object e) {
     if (mounted) {
       Navigator.of(context, rootNavigator: true).pop();
-      ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Erro: $e")));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text("Erro: $e")));
     }
   }
 
-  Widget _buildEnsaioCard(EnsaioModel item) {
-    return _baseCard(title: item.local, date: item.dataHora, subtitle: "Ensaio Geral");
-  }
-
-  Widget _baseCard({required String title, required DateTime date, String? subtitle, Widget? actionWidget}) {
+  Widget _baseCard(
+      {required String title,
+      required DateTime date,
+      String? subtitle,
+      Widget? actionWidget}) {
     return Card(
       margin: const EdgeInsets.only(bottom: 5),
       color: AppColors.cardBackground,
@@ -392,24 +603,29 @@ class _HomeViewState extends State<HomeView> {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
         child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center, 
+          crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(title, style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16)),
+                  Text(title,
+                      style: const TextStyle(
+                          fontWeight: FontWeight.bold, fontSize: 16)),
                   const SizedBox(height: 4),
-                  Text("📅 ${date.day}/${date.month} às ${date.hour}:${date.minute.toString().padLeft(2, '0')}"),
+                  Text(
+                      "📅 ${date.day}/${date.month} às ${date.hour}:${date.minute.toString().padLeft(2, '0')}"),
                   if (subtitle != null) ...[
                     const SizedBox(height: 2),
-                    Text(subtitle, style: const TextStyle(fontSize: 13, color: Colors.black54)),
+                    Text(subtitle,
+                        style: const TextStyle(
+                            fontSize: 13, color: Colors.black54)),
                   ]
                 ],
               ),
             ),
             if (actionWidget != null) ...[
-              const SizedBox(width: 8), 
+              const SizedBox(width: 8),
               actionWidget,
             ]
           ],
@@ -417,31 +633,62 @@ class _HomeViewState extends State<HomeView> {
       ),
     );
   }
-} 
+}
+
+class _StatusParticipacao extends StatelessWidget {
+  final String texto;
+  final IconData icone;
+  final Color cor;
+
+  const _StatusParticipacao({
+    required this.texto,
+    required this.icone,
+    required this.cor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: texto == 'AGUARDANDO'
+          ? 'Aguardando a aprovação do administrador.'
+          : 'Participação não aprovada.',
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icone, color: cor, size: 20),
+          Text(texto,
+              style: TextStyle(
+                  color: cor, fontSize: 9, fontWeight: FontWeight.bold)),
+        ],
+      ),
+    );
+  }
+}
 
 class EventToggleButton extends StatelessWidget {
   final bool isAccepted;
   final VoidCallback onPressed;
-  
-  const EventToggleButton({super.key, required this.isAccepted, required this.onPressed});
+
+  const EventToggleButton(
+      {super.key, required this.isAccepted, required this.onPressed});
 
   @override
   Widget build(BuildContext context) {
     return ElevatedButton(
       onPressed: onPressed,
       style: ElevatedButton.styleFrom(
-        backgroundColor: isAccepted ? Colors.grey : const Color(0xFFD9534F), 
-        foregroundColor: Colors.white, 
+        backgroundColor: isAccepted ? Colors.grey : const Color(0xFFD9534F),
+        foregroundColor: Colors.white,
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        minimumSize: Size.zero, 
-        tapTargetSize: MaterialTapTargetSize.shrinkWrap, 
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
         ),
-        elevation: 0, 
+        elevation: 0,
       ),
       child: Text(
-        isAccepted ? "CANCELAR" : "ACEITAR", 
+        isAccepted ? "CANCELAR" : "ACEITAR",
         style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 12),
       ),
     );

--- a/Codigo/GestaoGrupoMusicalMobile/lib/service/ensaio_service.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/service/ensaio_service.dart
@@ -7,47 +7,46 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 class EnsaioService {
-
-   final String baseUrl = ApiConfig.baseUrl;
-   static const String _cacheKey = 'ensaio_list';
+  final String baseUrl = ApiConfig.baseUrl;
+  static const String _cacheKey = 'ensaio_list';
 
   Future<List<EnsaioModel>> getAll() async {
     final userId = (await SessionManager.getIdPessoa())?.toString();
 
     try {
-      // Tenta recuperar do cache primeiro
       final cachedData = await CacheManager.getCache(_cacheKey, userId: userId);
       if (cachedData != null) {
-        debugPrint('Usando dados em cache isolados para ensaios do usuário $userId');
-        final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
+        debugPrint(
+            'Usando dados em cache isolados para ensaios do usuário $userId');
+        final List data =
+            cachedData is List ? cachedData : jsonDecode(cachedData);
         return data.map((e) => EnsaioModel.fromJson(e)).toList();
       }
     } catch (e) {
       debugPrint('Erro ao recuperar cache de ensaios: $e');
     }
 
-    // Se não tem cache válido, faz requisição HTTP
     try {
+      final token = await SessionManager.getToken();
       final response = await http.get(
         Uri.parse('$baseUrl/api/Ensaio'),
         headers: {
           'Accept': 'application/json',
+          'Authorization': 'Bearer $token',
         },
       );
 
       if (response.statusCode != 200) {
-        throw Exception('Erro ao buscar eventos');
+        throw Exception('Erro ao buscar ensaios');
       }
 
       final List data = jsonDecode(response.body);
       final ensaios = data.map((e) => EnsaioModel.fromJson(e)).toList();
-      
-      // Salva no cache
+
       await CacheManager.saveCache(_cacheKey, data);
-      
+
       return ensaios;
     } catch (e) {
-      // Se falhar a requisição, tenta retornar o cache mesmo que expirado
       debugPrint('Erro na requisição de ensaios, tentando cache expirado: $e');
       try {
         final prefs = await CacheManager.getStaleCache(_cacheKey);
@@ -59,9 +58,75 @@ class EnsaioService {
       rethrow;
     }
   }
+
+  // GET: Buscar a frequência/justificativa do associado no ensaio
+  Future<Map<String, dynamic>?> getMinhaFrequencia(int idEnsaio) async {
+    final token = await SessionManager.getToken();
+    try {
+      final response = await http.get(
+        Uri.parse('$baseUrl/api/Ensaio/DetalhesSolicitacao/$idEnsaio'),
+        headers: {
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+      );
+
+      if (response.statusCode == 200) {
+        return jsonDecode(response.body);
+      }
+      return null;
+    } catch (e) {
+      debugPrint('Erro ao buscar frequência/justificativa do ensaio: $e');
+      return null;
+    }
+  }
+
+  // POST: Enviar justificativa de ausência no ensaio
+  Future<String?> justificarAusencia(int idEnsaio, String justificativa) async {
+    final token = await SessionManager.getToken();
+    try {
+      final response = await http.post(
+        Uri.parse('$baseUrl/api/Ensaio/JustificarAusencia'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode({
+          'idEnsaio': idEnsaio,
+          'justificativa': justificativa,
+        }),
+      );
+
+      if (response.statusCode == 200) return null;
+      return _mensagemErro(response);
+    } catch (e) {
+      debugPrint('Erro ao enviar justificativa de ensaio: $e');
+      return 'Não foi possível conectar à API para enviar a justificativa.';
+    }
+  }
+
+  String _mensagemErro(http.Response response) {
+    if (response.statusCode == 401) {
+      return 'Sua sessão expirou. Entre novamente.';
+    }
+
+    if (response.statusCode == 403) {
+      return 'Você não tem permissão para justificar esta ausência.';
+    }
+
+    try {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final mensagem = data['mensagem'] as String?;
+      if (mensagem != null && mensagem.isNotEmpty) return mensagem;
+    } catch (_) {}
+
+    return 'Não foi possível enviar a justificativa (HTTP ${response.statusCode}).';
+  }
+
   Future<void> limparCacheListagem() async {
     final userId = (await SessionManager.getIdPessoa())?.toString();
-    
+
     try {
       await CacheManager.clearCache(_cacheKey, userId: userId);
     } catch (e) {

--- a/Codigo/GestaoGrupoMusicalMobile/lib/service/evento_service.dart
+++ b/Codigo/GestaoGrupoMusicalMobile/lib/service/evento_service.dart
@@ -19,7 +19,8 @@ class EventoService {
       final cachedData = await CacheManager.getCache(_cacheKey, userId: userId);
       if (cachedData != null) {
         debugPrint('Usando dados em cache isolados para o usuário $userId');
-        final List data = cachedData is List ? cachedData : jsonDecode(cachedData);
+        final List data =
+            cachedData is List ? cachedData : jsonDecode(cachedData);
         return data.map((e) => EventoModel.fromJson(e)).toList();
       }
     } catch (e) {
@@ -83,7 +84,8 @@ class EventoService {
           return null;
         }
       } else {
-        debugPrint("ERRO API: Status ${response.statusCode} - ${response.body}");
+        debugPrint(
+            "ERRO API: Status ${response.statusCode} - ${response.body}");
         return null;
       }
     } catch (e) {
@@ -92,8 +94,10 @@ class EventoService {
       return await CacheManager.getCache(cacheKey, userId: userId);
     }
   }
+
   // Métodos de POST (Participação e Cancelamento) permanecem iguais...
-  Future<String?> solicitarParticipacao(int idEvento, int idTipoInstrumento) async {
+  Future<String?> solicitarParticipacao(
+      int idEvento, int idTipoInstrumento) async {
     try {
       final token = await SessionManager.getToken();
       final response = await http.post(
@@ -135,11 +139,67 @@ class EventoService {
   // Novo método para forçar a limpeza do cache de eventos
   Future<void> limparCacheListagem() async {
     final userId = (await SessionManager.getIdPessoa())?.toString();
-    
+
     try {
       await CacheManager.clearCache(_cacheKey, userId: userId);
     } catch (e) {
       debugPrint('Erro ao limpar cache de eventos: $e');
     }
+  }
+
+  // POST: Enviar justificativa de ausência para o evento
+  Future<String?> justificarAusencia(int idEvento, String justificativa) async {
+    try {
+      final token = await SessionManager.getToken();
+      final response = await http.post(
+        Uri.parse('$baseUrl/api/Evento/JustificarAusencia'),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode({
+          'idEvento': idEvento,
+          'justificativa': justificativa,
+        }),
+      );
+
+      if (response.statusCode == 200) return null;
+      return _mensagemErro(response);
+    } catch (e) {
+      debugPrint('Erro ao enviar justificativa de evento: $e');
+      return 'Não foi possível conectar à API para enviar a justificativa.';
+    }
+  }
+
+  Future<void> limparCacheDetalhes(int idEvento) async {
+    final userId = (await SessionManager.getIdPessoa())?.toString();
+    await CacheManager.clearCache('$_detalhesCachePrefix$idEvento',
+        userId: userId);
+  }
+
+  String _mensagemErro(http.Response response) {
+    if (response.statusCode == 401) {
+      return 'Sua sessão expirou. Entre novamente.';
+    }
+
+    if (response.statusCode == 403) {
+      return 'Você não tem permissão para justificar esta ausência.';
+    }
+
+    try {
+      final data = jsonDecode(response.body) as Map<String, dynamic>;
+      final mensagem = data['mensagem'] as String?;
+      if (mensagem != null && mensagem.isNotEmpty) return mensagem;
+    } catch (_) {}
+
+    return 'Não foi possível enviar a justificativa (HTTP ${response.statusCode}).';
+  }
+
+  // GET: Consultar os detalhes/inscrição para verificar a justificativa enviada
+  Future<Map<String, dynamic>?> getMinhaInscricao(int idEvento) async {
+    // Como o seu getDetalhesEvento já busca o endpoint de detalhes do evento
+    // que retorna a propriedade 'minhaInscricao' / 'MinhaInscricao',
+    // podemos reutilizá-lo ou chamar diretamente se preferir.
+    return await getDetalhesEvento(idEvento);
   }
 }

--- a/Codigo/GestaoGrupoMusicalMobile/pubspec.lock
+++ b/Codigo/GestaoGrupoMusicalMobile/pubspec.lock
@@ -396,10 +396,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   native_toolchain_c:
     dependency: transitive
     description:
@@ -593,10 +593,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   timezone:
     dependency: transitive
     description:

--- a/Codigo/Service/EventoService.cs
+++ b/Codigo/Service/EventoService.cs
@@ -725,7 +725,8 @@ namespace Service
                                             ? ep.IdTipoInstrumentoNavigation.Nome
                                             : null,
                             Status = ep.Status,
-                            StatusEnum = ConvertAprovadoParaEnum(ep.Status)
+                            StatusEnum = ConvertAprovadoParaEnum(ep.Status),
+                            Justificativa = ep.JustificativaFalta
                         };
 
             return await query.AsNoTracking().FirstOrDefaultAsync();
@@ -1010,6 +1011,11 @@ namespace Service
                 if (eventoPessoa == null)
                 {
                     return HttpStatusCode.NotFound;
+                }
+
+                if (eventoPessoa.Status != InscricaoEventoPessoa.DEFERIDO.ToString())
+                {
+                    return HttpStatusCode.BadRequest;
                 }
 
                 eventoPessoa.JustificativaFalta = justificativa;


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/marcosdosea/GestaoGrupoMusical/assets/62726040/26118ce6-8a10-4f3a-b8a3-c3b90851b04b" width="10%">
  <h1>Pull Request</h1>
</div>

## Foi Solicitado

Implementar no aplicativo mobile um pop-up para o associado informar uma justificativa ao recusar ou informar ausência em ensaios e eventos. A API e o banco de dados deveriam receber, validar e armazenar essa justificativa.

Para eventos, a justificativa deve ficar disponível somente após a solicitação de participação do associado ser aprovada pelo administrador.

## Foi Feito

- [x] Criado o contrato de dados para envio de justificativas, com campo obrigatório e limite de 200 caracteres.
- [x] Implementado o endpoint `POST /api/Ensaio/JustificarAusencia`.
- [x] Implementado o endpoint `POST /api/Evento/JustificarAusencia`.
- [x] Implementada a consulta da justificativa já registrada para o ensaio.
- [x] Ajustada a API para identificar o associado pela claim `IdPessoa` do token JWT.
- [x] Incluída a justificativa nos detalhes da inscrição do evento.
- [x] Bloqueado o envio de justificativa de evento enquanto a inscrição não estiver aprovada (`DEFERIDO`).
- [x] Adicionado pop-up de justificativa para ensaios e eventos no mobile.
- [x] Adicionada validação no mobile para impedir o envio de justificativa vazia.
- [x] Adicionados estados visuais para o evento: solicitação de participação, aguardando aprovação, não aprovado e participação aprovada.
- [x] Exibido o botão de justificar ausência somente para eventos com participação aprovada.
- [x] Melhoradas as mensagens de erro do mobile para distinguir sessão expirada, falta de permissão, erro HTTP e indisponibilidade da API.

## Mudanças Que Não Estavam Previstas

- [x] Foi necessário corrigir o uso da claim do usuário autenticado, pois a claim `Id` contém um identificador GUID e não o identificador numérico da pessoa.
- [x] Foi necessário incluir a validação de status no backend para impedir que a regra de aprovação fosse burlada por chamadas diretas à API.

## Como Testar

1. Inicie ou reinicie a API para carregar as alterações.

   ```powershell
   dotnet run --project .\Codigo\GestaoGrupoMusicalAPI\GestaoGrupoMusicalAPI.csproj --launch-profile http
   ```

2. Execute o aplicativo mobile e faça login novamente para obter um token JWT válido.

   ```powershell
   cd .\Codigo\GestaoGrupoMusicalMobile
   flutter run
   ```

3. Teste a justificativa de ensaio:

   - Acesse a tela inicial do aplicativo.
   - Toque no ícone de justificativa de um ensaio.
   - Informe um motivo e envie.
   - Confirme a mensagem de sucesso.
   - Abra novamente o pop-up e confirme que o texto previamente salvo é exibido.

4. Teste o fluxo de evento aguardando aprovação:

   - Selecione um instrumento e solicite participação em um evento.
   - Confirme que o mobile exibe o estado **AGUARDANDO**.
   - Confirme que o botão de justificar ausência não é exibido nesse estado.

5. Teste o fluxo de evento aprovado:

   - No sistema web, aprove a solicitação do associado, deixando o status como `DEFERIDO`.
   - Atualize a tela inicial do mobile.
   - Confirme que o ícone de justificar ausência é exibido.
   - Envie uma justificativa e confirme a mensagem de sucesso.

6. Teste as validações:

   - Tente enviar o formulário vazio e confirme a mensagem solicitando o motivo da ausência.
   - Faça logout ou utilize um token expirado e confirme a mensagem **"Sua sessão expirou. Entre novamente."**.

## Prints

<img width="1858" height="678" alt="image" src="https://github.com/user-attachments/assets/310aa1de-cba6-4ee8-b91c-804c8b449098" />

<img width="720" height="1600" alt="c91ca710-aac6-4ac0-afa8-0c82f5aaa7a3" src="https://github.com/user-attachments/assets/407af023-7764-440c-8f8d-4bd084bb1079" />
<img width="720" height="1600" alt="761bfa85-e8a9-4033-8bfb-6e3693fc5f2d" src="https://github.com/user-attachments/assets/227f45b2-e1a1-4583-b358-11be09f1b64f" />
<img width="1864" height="540" alt="image" src="https://github.com/user-attachments/assets/72461b0b-ac3e-4625-8f77-3fa621f10b5b" />



**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**